### PR TITLE
Configure git user globally

### DIFF
--- a/src/jobs/publish.yml
+++ b/src/jobs/publish.yml
@@ -49,7 +49,7 @@ steps:
         - run:
             name: Configure git user
             working_directory: << parameters.app-dir >>
-            command: git config --local user.name << parameters.git-user-name >> && git config --local user.email << parameters.git-user-email >>
+            command: git config --global user.name << parameters.git-user-name >> && git config --global user.email << parameters.git-user-email >>
   - run:
       name: Authenticate with NPM
       command: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > ~/.npmrc

--- a/src/jobs/test.yml
+++ b/src/jobs/test.yml
@@ -45,7 +45,7 @@ steps:
         - run:
             name: Configure git user
             working_directory: << parameters.app-dir >>
-            command: git config --local user.name << parameters.git-user-name >> && git config --local user.email << parameters.git-user-email >>
+            command: git config --global user.name << parameters.git-user-name >> && git config --global user.email << parameters.git-user-email >>
   - run:
       name: Run tests
       working_directory: << parameters.app-dir >>


### PR DESCRIPTION
Relates to #17.

Local wasn't enough for https://github.com/chiubaka/nx-plugin/issues/48 since those tests are actually generating git projects outside of the local project directory.

I don't think it'll be a problem to configure the git user globally by default, so going ahead and making that change. Can always re-evaluate later if a case comes up that interferes with this.