### PR TITLE
Provide Codecov uploader a directory rather than specific file to upload

### DIFF
--- a/src/scripts/uploadMonorepoCoverageResults.sh
+++ b/src/scripts/uploadMonorepoCoverageResults.sh
@@ -1,4 +1,5 @@
 #! /usr/bin/env bash
+set -e
 
 # See https://github.com/codecov/uploader/issues/475
 unset NODE_OPTIONS
@@ -19,6 +20,12 @@ for project_name in "${!projects[@]}"
 do
   project_path=${projects[$project_name]}
   project_coverage_dir="$COVERAGE_DIR/$project_path"
+
+  if [ ! -d $project_coverage_dir ]
+  then
+    echo "Skipping coverage upload for $project_name because $project_coverage_dir does not exist"
+    continue
+  fi
 
   $CODECOV_BINARY \
     -t "$CODECOV_TOKEN" \

--- a/src/scripts/uploadMonorepoCoverageResults.sh
+++ b/src/scripts/uploadMonorepoCoverageResults.sh
@@ -23,7 +23,7 @@ do
   $CODECOV_BINARY \
     -t "$CODECOV_TOKEN" \
     -n "$CIRCLE_BUILD_NUM" \
-    -f "$project_coverage_dir" \
+    --dir "$project_coverage_dir" \
     -F "$project_name" \
     "$@"
 done

--- a/src/scripts/uploadMonorepoCoverageResults.sh
+++ b/src/scripts/uploadMonorepoCoverageResults.sh
@@ -21,7 +21,7 @@ do
   project_path=${projects[$project_name]}
   project_coverage_dir="$COVERAGE_DIR/$project_path"
 
-  if [ ! -d $project_coverage_dir ]
+  if [ ! -d "$project_coverage_dir" ]
   then
     echo "Skipping coverage upload for $project_name because $project_coverage_dir does not exist"
     continue

--- a/test/uploadMonorepoCoverageResults.bats
+++ b/test/uploadMonorepoCoverageResults.bats
@@ -1,6 +1,14 @@
 setup() {
   load "helpers/setup"
   _setup
+
+  COVERAGE_DIR="$TEST_DIR"/examples/coverage
+  mkdir -p "$COVERAGE_DIR"/packages/nx-plugin
+  mkdir -p "$COVERAGE_DIR"/e2e/nx-plugin-e2e
+}
+
+teardown() {
+  rm -rf "$COVERAGE_DIR"
 }
 
 @test "uploads one coverage report to Codecov per monorepo package" {
@@ -10,13 +18,52 @@ setup() {
   CODECOV_TOKEN=test-token \
   CIRCLE_BUILD_NUM=32 \
   WORKSPACE_JSON="$TEST_DIR"/examples/workspace.json \
-  COVERAGE_DIR=coverage \
+  COVERAGE_DIR=$COVERAGE_DIR \
   XTRA_ARGS="--extra extra-arg" \
   PARSE_NX_PROJECTS_SCRIPT="$PROJECT_ROOT"/src/scripts/parseNxProjects.sh \
   run uploadMonorepoCoverageResults.sh
 
   assert_success
   assert_equal "$(mock_get_call_num "${mock}")" 2
-  assert_equal "$(mock_get_call_args "${mock}" 1)" "-t test-token -n 32 --dir coverage/packages/nx-plugin -F nx-plugin --extra extra-arg"
-  assert_equal "$(mock_get_call_args "${mock}" 2)" "-t test-token -n 32 --dir coverage/e2e/nx-plugin-e2e -F nx-plugin-e2e --extra extra-arg"
+  assert_equal "$(mock_get_call_args "${mock}" 1)" "-t test-token -n 32 --dir $COVERAGE_DIR/packages/nx-plugin -F nx-plugin --extra extra-arg"
+  assert_equal "$(mock_get_call_args "${mock}" 2)" "-t test-token -n 32 --dir $COVERAGE_DIR/e2e/nx-plugin-e2e -F nx-plugin-e2e --extra extra-arg"
+}
+
+@test "skips upload gracefully if a project coverage directory does not exist" {
+  rm -d "$COVERAGE_DIR"/e2e/nx-plugin-e2e
+
+  mock=$(mock_create)
+  BASH_ENV=$TEST_DIR/examples/.bash_env \
+  CODECOV_BINARY="${mock}" \
+  CODECOV_TOKEN=test-token \
+  CIRCLE_BUILD_NUM=32 \
+  WORKSPACE_JSON="$TEST_DIR"/examples/workspace.json \
+  COVERAGE_DIR=$COVERAGE_DIR \
+  XTRA_ARGS="--extra extra-arg" \
+  PARSE_NX_PROJECTS_SCRIPT="$PROJECT_ROOT"/src/scripts/parseNxProjects.sh \
+  run uploadMonorepoCoverageResults.sh
+
+  assert_success
+  assert_output "Skipping coverage upload for nx-plugin-e2e because $COVERAGE_DIR/e2e/nx-plugin-e2e does not exist"
+  assert_equal "$(mock_get_call_num "${mock}")" 1
+  assert_equal "$(mock_get_call_args "${mock}" 1)" "-t test-token -n 32 --dir $COVERAGE_DIR/packages/nx-plugin -F nx-plugin --extra extra-arg"
+}
+
+@test "exits with an error if Codecov upload fails" {
+  mock=$(mock_create)
+  mock_set_status "${mock}" 1 2
+  BASH_ENV=$TEST_DIR/examples/.bash_env \
+  CODECOV_BINARY="${mock}" \
+  CODECOV_TOKEN=test-token \
+  CIRCLE_BUILD_NUM=32 \
+  WORKSPACE_JSON="$TEST_DIR"/examples/workspace.json \
+  COVERAGE_DIR=$COVERAGE_DIR \
+  XTRA_ARGS="--extra extra-arg" \
+  PARSE_NX_PROJECTS_SCRIPT="$PROJECT_ROOT"/src/scripts/parseNxProjects.sh \
+  run uploadMonorepoCoverageResults.sh
+
+  assert_failure
+  assert_equal "$(mock_get_call_num "${mock}")" 2
+  assert_equal "$(mock_get_call_args "${mock}" 1)" "-t test-token -n 32 --dir $COVERAGE_DIR/packages/nx-plugin -F nx-plugin --extra extra-arg"
+  assert_equal "$(mock_get_call_args "${mock}" 2)" "-t test-token -n 32 --dir $COVERAGE_DIR/e2e/nx-plugin-e2e -F nx-plugin-e2e --extra extra-arg"
 }

--- a/test/uploadMonorepoCoverageResults.bats
+++ b/test/uploadMonorepoCoverageResults.bats
@@ -52,6 +52,7 @@ teardown() {
 @test "exits with an error if Codecov upload fails" {
   mock=$(mock_create)
   mock_set_status "${mock}" 1 2
+
   BASH_ENV=$TEST_DIR/examples/.bash_env \
   CODECOV_BINARY="${mock}" \
   CODECOV_TOKEN=test-token \

--- a/test/uploadMonorepoCoverageResults.bats
+++ b/test/uploadMonorepoCoverageResults.bats
@@ -17,6 +17,6 @@ setup() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${mock}")" 2
-  assert_equal "$(mock_get_call_args "${mock}" 1)" "-t test-token -n 32 -f coverage/packages/nx-plugin -F nx-plugin --extra extra-arg"
-  assert_equal "$(mock_get_call_args "${mock}" 2)" "-t test-token -n 32 -f coverage/e2e/nx-plugin-e2e -F nx-plugin-e2e --extra extra-arg"
+  assert_equal "$(mock_get_call_args "${mock}" 1)" "-t test-token -n 32 --dir coverage/packages/nx-plugin -F nx-plugin --extra extra-arg"
+  assert_equal "$(mock_get_call_args "${mock}" 2)" "-t test-token -n 32 --dir coverage/e2e/nx-plugin-e2e -F nx-plugin-e2e --extra extra-arg"
 }

--- a/test/writeSharedScript.bats
+++ b/test/writeSharedScript.bats
@@ -2,15 +2,15 @@ setup() {
   load "helpers/setup"
   _setup
 
-  SCRIPT_DIR="$TEST_DIR"/@chiubaka/circleci-orb/scripts
-  SCRIPT_PATH="$TEST_DIR"/@chiubaka/circleci-orb/scripts/test.sh
+  SCRIPT_DIR="$TEST_DIR"/examples/@chiubaka/circleci-orb/scripts
+  SCRIPT_PATH="$SCRIPT_DIR"/test.sh
 
   SCRIPT="echo foobar" SCRIPT_DIR=$SCRIPT_DIR SCRIPT_NAME=test.sh run writeSharedScript.sh
 }
 
 teardown() {
   rm "$SCRIPT_PATH"
-  rm -r "$SCRIPT_DIR"
+  rm -d "$SCRIPT_DIR"
 }
 
 @test "writes the shared script to disc at the specified location" {


### PR DESCRIPTION
Relates to #21.

Also:
- Returns a non-0 exit status if Codecov uploader fails
- Gracefully skips upload for projects that don't have a coverage report directory