### PR TITLE
Fix typo missing paren in monorepo deploy task name

### DIFF
--- a/src/commands/deploy.yml
+++ b/src/commands/deploy.yml
@@ -26,7 +26,7 @@ steps:
             script-name: parseMonorepoDeployTag.sh
             script: << include(scripts/parseMonorepoDeployTag.sh) >>
         - run:
-            name: "[Monorepo] << parameters.task-name >> DRY_RUN=<< parameters.dry-run >>)"
+            name: "[Monorepo] << parameters.task-name >> (DRY_RUN=<< parameters.dry-run >>)"
             working_directory: << parameters.app-dir >>
             command: << include(scripts/deployMonorepoPackage.sh) >>
             environment:


### PR DESCRIPTION
Was just bothering me looking at this in the UI 🙃.