### PR TITLE
Remove setup_remote_docker command since we are not (yet) building docker containers in CI

### DIFF
--- a/src/commands/compose-docker.yml
+++ b/src/commands/compose-docker.yml
@@ -10,7 +10,6 @@ parameters:
 steps:
   - docker/install-docker
   - docker/install-docker-compose
-  - setup_remote_docker
   - run:
       name: Build images of services declared in docker-compose.yml
       command: docker-compose build


### PR DESCRIPTION
In response to build failures in `genesis`.