### PR TITLE
fix: Codecov upload path for workspace root package

### DIFF
--- a/src/scripts/uploadMonorepoCoverageResults.sh
+++ b/src/scripts/uploadMonorepoCoverageResults.sh
@@ -23,8 +23,20 @@ if [ -n "${XTRA_ARGS:-}" ]; then
 fi
 
 while IFS=$'\t' read -r pkg_name pkg_abs_path; do
-  pkg_rel_path="${pkg_abs_path#"$monorepo_root/"}"
-  project_coverage_dir="$COVERAGE_DIR/$pkg_rel_path"
+  # pnpm emits absolute paths with no trailing slash. For the workspace root
+  # package, pkg_abs_path equals monorepo_root, so "${path#$root/}" does not
+  # strip (there is no "/suffix") and pkg_rel_path would incorrectly stay
+  # absolute — e.g. COVERAGE_DIR + / + /home/circleci/project (double slash).
+  if [[ "$pkg_abs_path" == "$monorepo_root" ]]; then
+    project_coverage_dir="$COVERAGE_DIR"
+  else
+    pkg_rel_path="${pkg_abs_path#"$monorepo_root/"}"
+    if [[ "$pkg_rel_path" == "$pkg_abs_path" ]]; then
+      echo "ERROR: package path is not under MONOREPO_ROOT ($monorepo_root): $pkg_abs_path" >&2
+      exit 1
+    fi
+    project_coverage_dir="$COVERAGE_DIR/$pkg_rel_path"
+  fi
 
   if [ ! -d "$project_coverage_dir" ]
   then

--- a/test/uploadMonorepoCoverageResults.bats
+++ b/test/uploadMonorepoCoverageResults.bats
@@ -3,17 +3,44 @@ setup() {
   _setup
 
   COVERAGE_DIR="$TEST_DIR"/fixtures/coverage
-  mkdir -p "$COVERAGE_DIR"/packages/nx-plugin
-  mkdir -p "$COVERAGE_DIR"/e2e/nx-plugin-e2e
 
-  # Create a pnpm mock that outputs workspace packages as JSON with absolute paths
-  pnpm_mock=$(mock_create)
-  pnpm_ls_json="[{\"name\":\"nx-plugin\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"nx-plugin-e2e\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
-  mock_set_output "${pnpm_mock}" "$pnpm_ls_json"
+  # Workspace root package: path equals MONOREPO_ROOT (see uploadMonorepoCoverageResults.sh).
+  if [[ "${BATS_TEST_DESCRIPTION:-}" == *"workspace root package"* ]]; then
+    mkdir -p "$COVERAGE_DIR"
+    mkdir -p "$COVERAGE_DIR"/packages/nx-plugin
+    pnpm_mock=$(mock_create)
+    pnpm_ls_json="[{\"name\":\"root-workspace\",\"path\":\"$TEST_DIR\"},{\"name\":\"nx-plugin\",\"path\":\"$TEST_DIR/packages/nx-plugin\"}]"
+    mock_set_output "${pnpm_mock}" "$pnpm_ls_json"
+  else
+    mkdir -p "$COVERAGE_DIR"/packages/nx-plugin
+    mkdir -p "$COVERAGE_DIR"/e2e/nx-plugin-e2e
+    pnpm_mock=$(mock_create)
+    pnpm_ls_json="[{\"name\":\"nx-plugin\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"nx-plugin-e2e\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
+    mock_set_output "${pnpm_mock}" "$pnpm_ls_json"
+  fi
 }
 
 teardown() {
   rm -rf "$COVERAGE_DIR"
+}
+
+@test "uploads coverage for workspace root package to COVERAGE_DIR (no path join bug)" {
+  codecov_mock=$(mock_create)
+
+  BASH_ENV=$TEST_DIR/fixtures/.bash_env \
+  CODECOV_BINARY="${codecov_mock}" \
+  CODECOV_TOKEN=test-token \
+  CIRCLE_BUILD_NUM=32 \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR=$COVERAGE_DIR \
+  XTRA_ARGS="" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageResults.sh
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "-t test-token -n 32 --dir $COVERAGE_DIR -F root-workspace"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "-t test-token -n 32 --dir $COVERAGE_DIR/packages/nx-plugin -F nx-plugin"
 }
 
 @test "uploads one coverage report to Codecov per monorepo package" {


### PR DESCRIPTION
## Summary

pnpm `ls --json -r` lists the workspace root package with `path` equal to `MONOREPO_ROOT` (absolute, no trailing slash). The upload script used `${pkg_abs_path#"$monorepo_root/"}`, which does not strip in that case, so `pkg_rel_path` stayed an absolute filesystem path. Joining that with `COVERAGE_DIR` produced malformed paths such as `./reports/coverage//home/circleci/project`, and Codecov uploads for the root package were skipped or wrong.

## Changes

- Treat the root workspace package as a special case: use `COVERAGE_DIR` directly as the per-package coverage directory.
- Fail fast if a listed package path is not under `MONOREPO_ROOT`.
- Add a bats regression test that includes a root workspace entry whose path equals `MONOREPO_ROOT`.

## Verification

- `pnpm exec bats test/uploadMonorepoCoverageResults.bats`
- `pnpm lint:scripts`

Made with [Cursor](https://cursor.com)