### PR TITLE
fix(ci): require PR-local changeset file changes

### DIFF
--- a/.changeset/strict-verify-changeset-pr-touch.md
+++ b/.changeset/strict-verify-changeset-pr-touch.md
@@ -1,0 +1,9 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Require verify-changesets PR branches to touch a changeset markdown file.
+
+The default `verify-changesets` path now checks for `.changeset/*.md` changes against
+the configured primary branch before running `changeset status`, preventing false
+passes on branches that only inherit pending changesets from their base.

--- a/src/commands/verify-changesets.yml
+++ b/src/commands/verify-changesets.yml
@@ -12,6 +12,10 @@ parameters:
     default: ""
     description: >
       If empty, runs pnpm exec changeset status. If set, runs pnpm run <verify-script> instead.
+  primary-branch:
+    type: string
+    default: "master"
+    description: Branch used as the PR diff base for changeset file checks.
 
 steps:
   - run:
@@ -20,3 +24,4 @@ steps:
       command: << include(scripts/runVerifyChangesets.sh) >>
       environment:
         VERIFY_SCRIPT: << parameters.verify-script >>
+        PRIMARY_BRANCH: << parameters.primary-branch >>

--- a/src/jobs/verify-changesets.yml
+++ b/src/jobs/verify-changesets.yml
@@ -22,7 +22,7 @@ parameters:
   primary-branch:
     type: string
     default: "master"
-    description: Primary branch name for setup.
+    description: Primary branch name for setup and verify-changesets diff base.
   pre-install-steps:
     type: steps
     default: []

--- a/src/jobs/verify-changesets.yml
+++ b/src/jobs/verify-changesets.yml
@@ -59,4 +59,5 @@ steps:
   - verify-changesets:
       app-dir: << parameters.app-dir >>
       verify-script: << parameters.verify-script >>
+      primary-branch: << parameters.primary-branch >>
   - steps: << parameters.cleanup-steps >>

--- a/src/scripts/runVerifyChangesets.sh
+++ b/src/scripts/runVerifyChangesets.sh
@@ -4,8 +4,29 @@ set -euo pipefail
 
 pnpm_bin=${PNPM_BINARY:-pnpm}
 verify_script=${VERIFY_SCRIPT:-}
+primary_branch=${PRIMARY_BRANCH:-master}
 
 if [[ -z "$verify_script" ]]; then
+  merge_base=$(git merge-base HEAD "$primary_branch" 2>/dev/null || true)
+  if [[ -z "$merge_base" ]]; then
+    echo "ERROR: could not determine merge-base between HEAD and $primary_branch" >&2
+    exit 1
+  fi
+
+  has_changeset_markdown_change=false
+  while IFS= read -r changed_file; do
+    if [[ "$changed_file" == .changeset/*.md ]]; then
+      has_changeset_markdown_change=true
+      break
+    fi
+  done < <(git diff --name-only "$merge_base"...HEAD)
+
+  if [[ "$has_changeset_markdown_change" != true ]]; then
+    echo "ERROR: this branch must add or modify a .changeset/*.md file" >&2
+    echo "No changeset markdown file changes found versus $primary_branch." >&2
+    exit 1
+  fi
+
   exec "$pnpm_bin" exec changeset status
 fi
 

--- a/src/scripts/runVerifyChangesets.sh
+++ b/src/scripts/runVerifyChangesets.sh
@@ -5,21 +5,37 @@ set -euo pipefail
 pnpm_bin=${PNPM_BINARY:-pnpm}
 verify_script=${VERIFY_SCRIPT:-}
 primary_branch=${PRIMARY_BRANCH:-master}
+base_ref=$primary_branch
 
 if [[ -z "$verify_script" ]]; then
-  merge_base=$(git merge-base HEAD "$primary_branch" 2>/dev/null || true)
+  if ! git rev-parse --verify --quiet "$base_ref" >/dev/null; then
+    git fetch origin "$primary_branch":"refs/remotes/origin/$primary_branch" --depth=1 >/dev/null 2>&1 || true
+    base_ref="origin/$primary_branch"
+  fi
+
+  merge_base=$(git merge-base HEAD "$base_ref" 2>/dev/null || true)
+  if [[ -z "$merge_base" ]] && git rev-parse --is-shallow-repository >/dev/null 2>&1 && [[ "$(git rev-parse --is-shallow-repository)" == "true" ]]; then
+    git fetch --deepen=200 origin "$primary_branch" >/dev/null 2>&1 || git fetch --unshallow origin "$primary_branch" >/dev/null 2>&1 || true
+    merge_base=$(git merge-base HEAD "$base_ref" 2>/dev/null || true)
+  fi
+
   if [[ -z "$merge_base" ]]; then
-    echo "ERROR: could not determine merge-base between HEAD and $primary_branch" >&2
+    echo "ERROR: could not determine merge-base between HEAD and $base_ref" >&2
     exit 1
   fi
 
   has_changeset_markdown_change=false
-  while IFS= read -r changed_file; do
-    if [[ "$changed_file" == .changeset/*.md ]]; then
+  while IFS=$'\t' read -r status changed_file renamed_file; do
+    candidate_path=${renamed_file:-$changed_file}
+    case "$status" in
+      A*|M*|R*|C*) ;;
+      *) continue ;;
+    esac
+    if [[ "$candidate_path" == .changeset/*.md ]]; then
       has_changeset_markdown_change=true
       break
     fi
-  done < <(git diff --name-only "$merge_base"...HEAD)
+  done < <(git diff --name-status "$merge_base"...HEAD)
 
   if [[ "$has_changeset_markdown_change" != true ]]; then
     echo "ERROR: this branch must add or modify a .changeset/*.md file" >&2

--- a/test/runVerifyChangesets.bats
+++ b/test/runVerifyChangesets.bats
@@ -4,10 +4,26 @@ setup() {
 }
 
 @test "runs pnpm exec changeset status when VERIFY_SCRIPT is empty" {
+  repo_dir="${BATS_TEST_TMPDIR}/repo-default"
+  mkdir -p "${repo_dir}"
+  cd "${repo_dir}"
+  git init -b master >/dev/null
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  mkdir -p .changeset
+  printf "base\n" > .changeset/base.md
+  git add .changeset/base.md
+  git commit -m "base" >/dev/null
+  git checkout -b feature >/dev/null
+  printf "update\n" > .changeset/base.md
+  git add .changeset/base.md
+  git commit -m "touch changeset" >/dev/null
+
   mock=$(mock_create)
 
   PNPM_BINARY="${mock}" \
   VERIFY_SCRIPT='' \
+  PRIMARY_BRANCH=master \
   run runVerifyChangesets.sh
 
   assert_success
@@ -24,4 +40,32 @@ setup() {
 
   assert_success
   assert_equal "$(mock_get_call_args "${mock}")" "run changeset:check"
+}
+
+@test "fails when branch does not touch a changeset markdown file" {
+  repo_dir="${BATS_TEST_TMPDIR}/repo-no-changeset-touch"
+  mkdir -p "${repo_dir}"
+  cd "${repo_dir}"
+  git init -b master >/dev/null
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  mkdir -p .changeset
+  printf "base\n" > .changeset/base.md
+  git add .changeset/base.md
+  git commit -m "base" >/dev/null
+  git checkout -b feature >/dev/null
+  printf "readme\n" > README.md
+  git add README.md
+  git commit -m "docs" >/dev/null
+
+  mock=$(mock_create)
+
+  PNPM_BINARY="${mock}" \
+  VERIFY_SCRIPT='' \
+  PRIMARY_BRANCH=master \
+  run runVerifyChangesets.sh
+
+  assert_failure
+  assert_equal "$(mock_get_call_num "${mock}")" 0
+  assert_output --partial "must add or modify a .changeset/*.md file"
 }

--- a/test/runVerifyChangesets.bats
+++ b/test/runVerifyChangesets.bats
@@ -69,3 +69,26 @@ setup() {
   assert_equal "$(mock_get_call_num "${mock}")" 0
   assert_output --partial "must add or modify a .changeset/*.md file"
 }
+
+@test "fails with clear error when merge-base cannot be determined" {
+  repo_dir="${BATS_TEST_TMPDIR}/repo-no-primary-branch"
+  mkdir -p "${repo_dir}"
+  cd "${repo_dir}"
+  git init -b master >/dev/null
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  printf "readme\n" > README.md
+  git add README.md
+  git commit -m "base" >/dev/null
+
+  mock=$(mock_create)
+
+  PNPM_BINARY="${mock}" \
+  VERIFY_SCRIPT='' \
+  PRIMARY_BRANCH=does-not-exist \
+  run runVerifyChangesets.sh
+
+  assert_failure
+  assert_equal "$(mock_get_call_num "${mock}")" 0
+  assert_output --partial "could not determine merge-base"
+}


### PR DESCRIPTION
## Summary
- enforce `verify-changesets` default mode to require at least one `.changeset/*.md` file changed on the PR branch versus the primary branch
- thread `primary-branch` through the verify command so the diff base is explicit and configurable
- add Bats coverage for pass/fail scenarios and include a patch changeset entry

## Test plan
- [x] `pnpm exec bats ./test/runVerifyChangesets.bats`
- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build` (fails in this environment: `circleci local execute` cannot find `orb-tools/pack` job)
- [ ] `pnpm typecheck` (script is not defined in this repository)


Made with [Cursor](https://cursor.com)