### PR TITLE
fix(changesets): include untracked changelog excerpts in release PR body

### DIFF
--- a/.changeset/fix-release-pr-untracked-changelog-excerpts.md
+++ b/.changeset/fix-release-pr-untracked-changelog-excerpts.md
@@ -1,0 +1,7 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Include excerpts from newly added CHANGELOG files in release PR bodies.
+
+Fixes release PR body generation so changelog excerpts are collected from both tracked diffs and untracked files created by `changeset version`.

--- a/src/scripts/runChangesetsReleasePr.sh
+++ b/src/scripts/runChangesetsReleasePr.sh
@@ -58,7 +58,7 @@ list_changed_changelog_paths() {
   {
     git diff --name-only
     git ls-files --others --exclude-standard
-  } | grep -E '(^|/)CHANGELOG\.md$' | LC_ALL=C sort -u
+  } | { grep -E '(^|/)CHANGELOG\.md$' || :; } | LC_ALL=C sort -u
 }
 
 build_pr_body_file() {

--- a/src/scripts/runChangesetsReleasePr.sh
+++ b/src/scripts/runChangesetsReleasePr.sh
@@ -54,6 +54,13 @@ extract_changelog_top() {
   ' "$file"
 }
 
+list_changed_changelog_paths() {
+  {
+    git diff --name-only
+    git ls-files --others --exclude-standard
+  } | grep -E '(^|/)CHANGELOG\.md$' | LC_ALL=C sort -u
+}
+
 build_pr_body_file() {
   local out=$1
   {
@@ -81,7 +88,7 @@ build_pr_body_file() {
       printf '%s\n' "$excerpt"
       echo
     } >>"$out"
-  done < <(git diff --name-only | grep -E '(^|/)CHANGELOG\.md$' || true)
+  done < <(list_changed_changelog_paths || true)
 
   node -e 'const fs=require("fs");const p=process.argv[1];const m=55000;let t=fs.readFileSync(p,"utf8");if(t.length>m){t=t.slice(0,m)+"\n\n_(body truncated for GitHub length limits)_\n";fs.writeFileSync(p,t);}' "$out" 2>/dev/null || true
 }

--- a/test/runChangesetsReleasePr.bats
+++ b/test/runChangesetsReleasePr.bats
@@ -109,6 +109,30 @@ EOF
   rm -f "$body"
 }
 
+@test "build_pr_body_file includes excerpt from newly added untracked CHANGELOG.md" {
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  git init -b main
+  git config user.email test@test
+  git config user.name Test
+  printf '%s\n' '{"name":"@t/root","version":"1.0.0"}' >package.json
+  git add package.json && git commit -m "init"
+
+  cat >CHANGELOG.md <<'EOF'
+# @t/root
+## 1.1.0
+### Patch Changes
+- include untracked changelog excerpt
+EOF
+
+  body=$(mktemp)
+  build_pr_body_file "$body"
+  run grep -F "@t/root" "$body"
+  assert_success
+  run grep -F "include untracked changelog excerpt" "$body"
+  assert_success
+  rm -f "$body"
+}
+
 @test "mktemp EXIT cleanup keeps body_file non-local so trap survives function return (set -u)" {
   # Regression: local body_file + trap 'rm -f "$body_file"' on EXIT — after f returns the
   # local is gone and set -u errors on "unbound variable" when the trap runs.


### PR DESCRIPTION
## Summary
- fix `changesets-release-pr` changelog excerpt collection to include both tracked diffs and untracked files, so newly generated `CHANGELOG.md` files are included
- add a regression test for the untracked root `CHANGELOG.md` scenario that previously produced the fallback-only PR body
- add a patch changeset with a concise changelog-ready first line

## Test plan
- [x] `pnpm exec bats test/runChangesetsReleasePr.bats`
- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] `pnpm build` (fails in local env: `circleci local execute` cannot resolve `orb-tools/pack` job)
- [ ] `pnpm typecheck` (no `typecheck` script defined in root `package.json`)

Made with [Cursor](https://cursor.com)