### PR TITLE
fix(ci): skip workspace-root Codecov coverage upload

### DIFF
--- a/.changeset/skip-root-codecov-upload.md
+++ b/.changeset/skip-root-codecov-upload.md
@@ -1,0 +1,11 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Skip pnpm workspace root in `upload_monorepo_coverage` Codecov uploads
+
+The `uploadMonorepoCoverageWithCodecovCli` script no longer passes the entire coverage
+root to Codecov under the workspace root package name, avoiding duplicate per-package
+uploads and collisions with path-scoped Codecov `flags` that reuse that name. Each leaf
+package still uploads when `reports/coverage/<relpath>` exists. Tests and the orb command
+description were updated to match.

--- a/src/commands/upload-monorepo-coverage.yml
+++ b/src/commands/upload-monorepo-coverage.yml
@@ -1,5 +1,9 @@
 description: >
-  This command uploads coverage reports for monorepos to Codecov
+  Uploads Codecov coverage for each pnpm workspace package that has a matching directory under
+  the coverage path (for example reports/coverage/<packagePath>). The workspace root package
+  is skipped: there is no separate upload for the entire tree under the coverage root, so the
+  root `package.json` name is not used as a Codecov flag. Leaf packages under the workspace
+  continue to receive one upload each when their per-package coverage directory exists.
 
 parameters:
   app-dir:

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -46,15 +46,18 @@ IFS=',' read -r -a configured_flags <<< "${CODECOV_FLAGS:-}"
 
 while IFS=$'\t' read -r package_name package_abs_path; do
   if [[ "$package_abs_path" == "$monorepo_root" ]]; then
-    package_coverage_dir="$coverage_root"
-  else
-    package_rel_path="${package_abs_path#"$monorepo_root/"}"
-    if [[ "$package_rel_path" == "$package_abs_path" ]]; then
-      echo "ERROR: package path is not under MONOREPO_ROOT ($monorepo_root): $package_abs_path" >&2
-      exit 1
-    fi
-    package_coverage_dir="$coverage_root/$package_rel_path"
+    # pnpm includes the workspace root; do not upload reports/coverage as one tree under the root
+    # package name (it duplicates leaf uploads and can collide with path-scoped Codecov flags).
+    echo "Skipping coverage upload for workspace root package $package_name; per-package subdirectories only"
+    continue
   fi
+
+  package_rel_path="${package_abs_path#"$monorepo_root/"}"
+  if [[ "$package_rel_path" == "$package_abs_path" ]]; then
+    echo "ERROR: package path is not under MONOREPO_ROOT ($monorepo_root): $package_abs_path" >&2
+    exit 1
+  fi
+  package_coverage_dir="$coverage_root/$package_rel_path"
 
   if [[ ! -d "$package_coverage_dir" ]]; then
     echo "Skipping coverage upload for $package_name because $package_coverage_dir does not exist"

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -52,6 +52,29 @@ teardown() {
   assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin"
 }
 
+@test "skips workspace root package; does not upload full coverage tree under root name" {
+  pnpm_ls_with_root="[{\"name\":\"monorepo-root\",\"path\":\"$TEST_DIR\"},{\"name\":\"nx-plugin\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"nx-plugin-e2e\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
+  mock_set_output "${pnpm_mock}" "$pnpm_ls_with_root"
+  # Entire tree exists under coverage root, but root must not trigger one -F monorepo-root upload.
+  mkdir -p "$COVERAGE_DIR"
+  touch "$COVERAGE_DIR"/.placeholder
+
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_output --partial "Skipping coverage upload for workspace root package monorepo-root; per-package subdirectories only"
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e"
+}
+
 @test "skips packages with missing coverage directories" {
   rm -d "$COVERAGE_DIR"/e2e/nx-plugin-e2e
   codecov_mock=$(mock_create)


### PR DESCRIPTION
Avoid uploading the monorepo coverage root under the workspace package name. Only leaf workspace package coverage directories are uploaded, preventing duplicate full-tree flags and Codecov flag collisions.

Made-with: Cursor