### PR TITLE
fix(codecov): normalize monorepo package flags for Codecov uploads

### DIFF
--- a/.changeset/fuzzy-tools-juggle.md
+++ b/.changeset/fuzzy-tools-juggle.md
@@ -1,0 +1,7 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Normalize monorepo package-derived Codecov flags to valid Codecov flag names.
+
+Scoped package names now upload with normalized flags (for example `@chiubaka/lint` becomes `chiubaka-lint`) so monorepo coverage uploads do not fail on invalid flag characters. If your `codecov.yml` uses `individual_flags`, update names to the normalized values used by uploads.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,4 +62,11 @@ Repository-specific guidance in the local override section of `AGENTS.md` takes 
 
 <!-- REPO_OVERRIDES_START -->
 _Repository-specific overrides go here. These take precedence over org defaults._
+
+## Repo release-notes policy
+
+- Do not maintain a running migration log, release notes ledger, or shadow changelog in `README.md`.
+- Record normal release-facing changes through `.changeset/*.md`; generated changelog output is the canonical release history.
+- Add README migration guidance only for large, breaking transitions that require durable operator context not appropriate for a single changeset entry.
+- When such README migration guidance is necessary, keep it focused on actionable migration steps and remove it after it is no longer needed.
 <!-- REPO_OVERRIDES_END -->

--- a/README.md
+++ b/README.md
@@ -15,6 +15,22 @@ _**Edit this area to include a custom title and description.**_
 
 ## Migration Notes
 
+### v0.16.1
+
+`v0.16.1` fixes monorepo Codecov flag uploads for scoped npm package names.
+
+- Package-derived monorepo flags are now normalized to Codecov-safe names.
+- Normalization rules for package-derived flags:
+  - remove leading `@`
+  - replace `/` with `-`
+  - replace unsupported characters with `-`
+  - truncate to Codecov's 45-character limit
+- Example: `@chiubaka/lint` uploads with flag `chiubaka-lint`.
+- Additional flags supplied through the `flags` parameter are passed through unchanged.
+
+If your `codecov.yml` uses `individual_flags`, ensure each `name` matches the normalized flag
+value used by uploads.
+
 ### v0.16.0
 
 `v0.16.0` includes a Codecov upgrade and a breaking API change for monorepo coverage uploads.

--- a/README.md
+++ b/README.md
@@ -15,22 +15,6 @@ _**Edit this area to include a custom title and description.**_
 
 ## Migration Notes
 
-### v0.16.1
-
-`v0.16.1` fixes monorepo Codecov flag uploads for scoped npm package names.
-
-- Package-derived monorepo flags are now normalized to Codecov-safe names.
-- Normalization rules for package-derived flags:
-  - remove leading `@`
-  - replace `/` with `-`
-  - replace unsupported characters with `-`
-  - truncate to Codecov's 45-character limit
-- Example: `@chiubaka/lint` uploads with flag `chiubaka-lint`.
-- Additional flags supplied through the `flags` parameter are passed through unchanged.
-
-If your `codecov.yml` uses `individual_flags`, ensure each `name` matches the normalized flag
-value used by uploads.
-
 ### v0.16.0
 
 `v0.16.0` includes a Codecov upgrade and a breaking API change for monorepo coverage uploads.

--- a/src/commands/upload-monorepo-coverage.yml
+++ b/src/commands/upload-monorepo-coverage.yml
@@ -3,7 +3,9 @@ description: >
   the coverage path (for example reports/coverage/<packagePath>). The workspace root package
   is skipped: there is no separate upload for the entire tree under the coverage root, so the
   root `package.json` name is not used as a Codecov flag. Leaf packages under the workspace
-  continue to receive one upload each when their per-package coverage directory exists.
+  continue to receive one upload each when their per-package coverage directory exists. Package
+  names are normalized to Codecov-safe flags (for example `@chiubaka/lint` becomes
+  `chiubaka-lint`) before upload.
 
 parameters:
   app-dir:
@@ -39,7 +41,7 @@ parameters:
   flags:
     type: string
     default: ""
-    description: Comma-separated list of Codecov flags for this upload.
+    description: Comma-separated list of additional Codecov flags for this upload.
 
 steps:
   - run:

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -44,6 +44,85 @@ fi
 IFS=',' read -r -a configured_files <<< "${CODECOV_FILES:-}"
 IFS=',' read -r -a configured_flags <<< "${CODECOV_FLAGS:-}"
 
+sanitize_package_flag() {
+  local package_name="$1"
+  local sanitized
+
+  sanitized="${package_name#@}"
+  sanitized="${sanitized//\//-}"
+  sanitized="$(printf '%s' "$sanitized" | sed -E 's/[^[:alnum:]_.-]+/-/g; s/-+/-/g; s/^[._-]+//; s/[._-]+$//')"
+  sanitized="${sanitized:0:45}"
+  sanitized="$(printf '%s' "$sanitized" | sed -E 's/[._-]+$//')"
+
+  if [[ -z "$sanitized" ]]; then
+    sanitized="pkg"
+  fi
+
+  printf '%s' "$sanitized"
+}
+
+short_hash() {
+  local input="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$input" | sha256sum | cut -c1-8
+    return
+  fi
+
+  if command -v shasum >/dev/null 2>&1; then
+    printf '%s' "$input" | shasum -a 256 | cut -c1-8
+    return
+  fi
+
+  echo "ERROR: neither sha256sum nor shasum is available for flag collision handling." >&2
+  exit 1
+}
+
+resolve_unique_flag() {
+  local package_name="$1"
+  local base_flag="$2"
+  local existing_package
+  local hashed_flag hash_suffix hash base_limit truncated_base
+
+  existing_package="${flag_to_package[$base_flag]-}"
+  if [[ -z "$existing_package" ]]; then
+    printf '%s' "$base_flag"
+    return
+  fi
+
+  if [[ "$existing_package" == "$package_name" ]]; then
+    printf '%s' "$base_flag"
+    return
+  fi
+
+  hash="$(short_hash "$package_name")"
+  hash_suffix="-$hash"
+  base_limit=$((45 - ${#hash_suffix}))
+
+  if (( base_limit < 1 )); then
+    echo "ERROR: unable to derive unique Codecov flag for package $package_name." >&2
+    exit 1
+  fi
+
+  truncated_base="${base_flag:0:$base_limit}"
+  truncated_base="$(printf '%s' "$truncated_base" | sed -E 's/[._-]+$//')"
+  if [[ -z "$truncated_base" ]]; then
+    truncated_base="pkg"
+  fi
+  hashed_flag="${truncated_base}${hash_suffix}"
+
+  existing_package="${flag_to_package[$hashed_flag]-}"
+  if [[ -n "$existing_package" ]] && [[ "$existing_package" != "$package_name" ]]; then
+    echo "ERROR: flag collision detected after sanitization: $package_name and $existing_package both map to $hashed_flag." >&2
+    exit 1
+  fi
+
+  printf '%s' "$hashed_flag"
+}
+
+declare -A package_to_flag=()
+declare -A flag_to_package=()
+
 while IFS=$'\t' read -r package_name package_abs_path; do
   if [[ "$package_abs_path" == "$monorepo_root" ]]; then
     # pnpm includes the workspace root; do not upload reports/coverage as one tree under the root
@@ -64,12 +143,22 @@ while IFS=$'\t' read -r package_name package_abs_path; do
     continue
   fi
 
+  package_flag="${package_to_flag[$package_name]-}"
+  if [[ -z "$package_flag" ]]; then
+    base_flag="$(sanitize_package_flag "$package_name")"
+    package_flag="$(resolve_unique_flag "$package_name" "$base_flag")"
+    package_to_flag["$package_name"]="$package_flag"
+    flag_to_package["$package_flag"]="$package_name"
+  fi
+
+  echo "Uploading coverage for package $package_name using Codecov flag $package_flag"
+
   upload_args=(
     upload-coverage
     --dir "$package_coverage_dir"
     --network-root-folder "$monorepo_root"
     --name "$package_name"
-    --flag "$package_name"
+    --flag "$package_flag"
   )
   upload_args+=("${common_args[@]}")
 

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -37,6 +37,81 @@ teardown() {
   assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e --fail-on-error --verbose --disable-search --file coverage.xml --file coverage-final.json --flag unit --flag monorepo"
 }
 
+@test "sanitizes scoped package names into Codecov-safe flags" {
+  scoped_pnpm_ls_json="[{\"name\":\"@chiubaka/lint\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"@chiubaka/e2e-tests\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
+  mock_set_output "${pnpm_mock}" "$scoped_pnpm_ls_json"
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/lint --flag chiubaka-lint"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @chiubaka/e2e-tests --flag chiubaka-e2e-tests"
+}
+
+@test "normalizes disallowed characters in package-derived flags" {
+  weird_pnpm_ls_json="[{\"name\":\"@chiubaka/pkg!!name\",\"path\":\"$TEST_DIR/packages/nx-plugin\"}]"
+  mock_set_output "${pnpm_mock}" "$weird_pnpm_ls_json"
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 1
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/pkg!!name --flag chiubaka-pkg-name"
+}
+
+@test "truncates long package-derived flags to Codecov max length" {
+  long_name="@scope/abcdefghijklmnopqrstuvwxyz1234567890abcdefghijk"
+  long_pnpm_ls_json="[{\"name\":\"$long_name\",\"path\":\"$TEST_DIR/packages/nx-plugin\"}]"
+  mock_set_output "${pnpm_mock}" "$long_pnpm_ls_json"
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 1
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name $long_name --flag scope-abcdefghijklmnopqrstuvwxyz1234567890abc"
+}
+
+@test "adds hash suffix when sanitized flags collide" {
+  colliding_pnpm_ls_json="[{\"name\":\"@a/b\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"a-b\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
+  mock_set_output "${pnpm_mock}" "$colliding_pnpm_ls_json"
+  codecov_mock=$(mock_create)
+
+  run bash -lc "printf '%s' 'a-b' | sha256sum | cut -c1-8"
+  assert_success
+  hash_suffix="$output"
+
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @a/b --flag a-b"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name a-b --flag a-b-$hash_suffix"
+}
+
 @test "omits token and optional args when unset" {
   codecov_mock=$(mock_create)
 


### PR DESCRIPTION
Sanitize package-derived monorepo flags to Codecov-safe names, add deterministic collision handling, and preserve passthrough extra flags. Document the new behavior and add test coverage and a patch changeset for client migration.

Made-with: Cursor