### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.16.1)

### DIFF
--- a/.changeset/fuzzy-tools-juggle.md
+++ b/.changeset/fuzzy-tools-juggle.md
@@ -1,7 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Normalize monorepo package-derived Codecov flags to valid Codecov flag names.
-
-Scoped package names now default to the post-scope segment for Codecov flags (for example `@chiubaka/lint` becomes `lint`) so monorepo coverage uploads align with package identities. When unscoped names collide, uploads fall back to a scope-prefixed flag only if it resolves the collision; unresolved collisions now fail loudly so you can fix naming deterministically.

--- a/.changeset/mean-mice-poke.md
+++ b/.changeset/mean-mice-poke.md
@@ -1,7 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fail Codecov monorepo uploads loudly by default when uploads fail or do not happen.
-
-`upload-monorepo-coverage` now defaults `fail-on-error` and `verbose` to `true`, and adds `require-uploads` (default `true`) so CI fails when no per-package coverage uploads occur. Set `require-uploads: false` only for workflows where empty uploads are expected.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @chiubaka/circleci-orb
 
+## 0.16.1
+
+### Patch Changes
+
+- 164958d: Normalize monorepo package-derived Codecov flags to valid Codecov flag names.
+
+  Scoped package names now default to the post-scope segment for Codecov flags (for example `@chiubaka/lint` becomes `lint`) so monorepo coverage uploads align with package identities. When unscoped names collide, uploads fall back to a scope-prefixed flag only if it resolves the collision; unresolved collisions now fail loudly so you can fix naming deterministically.
+
+- 626eef6: Fail Codecov monorepo uploads loudly by default when uploads fail or do not happen.
+
+  `upload-monorepo-coverage` now defaults `fail-on-error` and `verbose` to `true`, and adds `require-uploads` (default `true`) so CI fails when no per-package coverage uploads occur. Set `require-uploads: false` only for workflows where empty uploads are expected.
+
 ## 0.16.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
## Changelog excerpts

Automated version bump via Changesets (release PR).

### @chiubaka/circleci-orb


### Patch Changes

- 164958d: Normalize monorepo package-derived Codecov flags to valid Codecov flag names.

  Scoped package names now default to the post-scope segment for Codecov flags (for example `@chiubaka/lint` becomes `lint`) so monorepo coverage uploads align with package identities. When unscoped names collide, uploads fall back to a scope-prefixed flag only if it resolves the collision; unresolved collisions now fail loudly so you can fix naming deterministically.

- 626eef6: Fail Codecov monorepo uploads loudly by default when uploads fail or do not happen.

  `upload-monorepo-coverage` now defaults `fail-on-error` and `verbose` to `true`, and adds `require-uploads` (default `true`) so CI fails when no per-package coverage uploads occur. Set `require-uploads: false` only for workflows where empty uploads are expected.

