### PR TITLE
fix(codecov): fail loudly on missing monorepo coverage uploads

### DIFF
--- a/.changeset/mean-mice-poke.md
+++ b/.changeset/mean-mice-poke.md
@@ -1,0 +1,7 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fail Codecov monorepo uploads loudly by default when uploads fail or do not happen.
+
+`upload-monorepo-coverage` now defaults `fail-on-error` and `verbose` to `true`, and adds `require-uploads` (default `true`) so CI fails when no per-package coverage uploads occur. Set `require-uploads: false` only for workflows where empty uploads are expected.

--- a/src/commands/upload-monorepo-coverage.yml
+++ b/src/commands/upload-monorepo-coverage.yml
@@ -24,12 +24,16 @@ parameters:
     description: Path relative to app-dir where coverage reports can be found
   fail-on-error:
     type: boolean
-    default: false
-    description: Exit non-zero when an upload fails.
+    default: true
+    description: Exit non-zero when an upload fails (recommended default).
   verbose:
     type: boolean
-    default: false
-    description: Enable verbose Codecov logs.
+    default: true
+    description: Enable verbose Codecov logs by default.
+  require-uploads:
+    type: boolean
+    default: true
+    description: Exit non-zero when no per-package coverage upload occurs.
   disable-search:
     type: boolean
     default: false
@@ -54,5 +58,6 @@ steps:
         CODECOV_FAIL_ON_ERROR: << parameters.fail-on-error >>
         CODECOV_VERBOSE: << parameters.verbose >>
         CODECOV_DISABLE_SEARCH: << parameters.disable-search >>
+        CODECOV_REQUIRE_UPLOADS: << parameters.require-uploads >>
         CODECOV_FILES: << parameters.files >>
         CODECOV_FLAGS: << parameters.flags >>

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -28,10 +28,10 @@ if ! command -v "$codecov_bin" >/dev/null 2>&1; then
 fi
 
 common_args=()
-if [[ "${CODECOV_FAIL_ON_ERROR:-false}" == "true" ]] || [[ "${CODECOV_FAIL_ON_ERROR:-0}" == "1" ]]; then
+if [[ "${CODECOV_FAIL_ON_ERROR:-true}" == "true" ]] || [[ "${CODECOV_FAIL_ON_ERROR:-1}" == "1" ]]; then
   common_args+=(--fail-on-error)
 fi
-if [[ "${CODECOV_VERBOSE:-false}" == "true" ]] || [[ "${CODECOV_VERBOSE:-0}" == "1" ]]; then
+if [[ "${CODECOV_VERBOSE:-true}" == "true" ]] || [[ "${CODECOV_VERBOSE:-1}" == "1" ]]; then
   common_args+=(--verbose)
 fi
 if [[ "${CODECOV_DISABLE_SEARCH:-false}" == "true" ]] || [[ "${CODECOV_DISABLE_SEARCH:-0}" == "1" ]]; then
@@ -122,6 +122,12 @@ resolve_unique_flag() {
 
 declare -A package_to_flag=()
 declare -A flag_to_package=()
+upload_count=0
+if [[ "${CODECOV_REQUIRE_UPLOADS:-true}" == "true" ]] || [[ "${CODECOV_REQUIRE_UPLOADS:-1}" == "1" ]]; then
+  require_uploads=true
+else
+  require_uploads=false
+fi
 
 while IFS=$'\t' read -r package_name package_abs_path; do
   if [[ "$package_abs_path" == "$monorepo_root" ]]; then
@@ -179,4 +185,10 @@ while IFS=$'\t' read -r package_name package_abs_path; do
   done
 
   "$codecov_bin" "${upload_args[@]}"
+  upload_count=$((upload_count + 1))
 done < <($pnpm_bin ls --json -r 2>/dev/null | jq -r '.[] | "\(.name)\t\(.path)"')
+
+if [[ "$require_uploads" == "true" ]] && (( upload_count == 0 )); then
+  echo "ERROR: no coverage reports were uploaded. Ensure per-package coverage directories exist under $coverage_root or set CODECOV_REQUIRE_UPLOADS=false to allow empty uploads." >&2
+  exit 1
+fi

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -51,8 +51,8 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/lint --flag chiubaka-lint"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @chiubaka/e2e-tests --flag chiubaka-e2e-tests"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/lint --flag chiubaka-lint --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @chiubaka/e2e-tests --flag chiubaka-e2e-tests --fail-on-error --verbose"
 }
 
 @test "normalizes disallowed characters in package-derived flags" {
@@ -69,7 +69,7 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 1
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/pkg!!name --flag chiubaka-pkg-name"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/pkg!!name --flag chiubaka-pkg-name --fail-on-error --verbose"
 }
 
 @test "truncates long package-derived flags to Codecov max length" {
@@ -87,7 +87,7 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 1
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name $long_name --flag scope-abcdefghijklmnopqrstuvwxyz1234567890abc"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name $long_name --flag scope-abcdefghijklmnopqrstuvwxyz1234567890abc --fail-on-error --verbose"
 }
 
 @test "adds hash suffix when sanitized flags collide" {
@@ -108,11 +108,29 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @a/b --flag a-b"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name a-b --flag a-b-$hash_suffix"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @a/b --flag a-b --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name a-b --flag a-b-$hash_suffix --fail-on-error --verbose"
 }
 
 @test "omits token and optional args when unset" {
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  CODECOV_FAIL_ON_ERROR=false \
+  CODECOV_VERBOSE=false \
+  CODECOV_REQUIRE_UPLOADS=false \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin"
+}
+
+@test "defaults fail-on-error and verbose to true" {
   codecov_mock=$(mock_create)
 
   CODECOV_TOKEN='' \
@@ -124,7 +142,7 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin --fail-on-error --verbose"
 }
 
 @test "skips workspace root package; does not upload full coverage tree under root name" {
@@ -146,8 +164,8 @@ teardown() {
   assert_success
   assert_output --partial "Skipping coverage upload for workspace root package monorepo-root; per-package subdirectories only"
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e --fail-on-error --verbose"
 }
 
 @test "skips packages with missing coverage directories" {
@@ -156,6 +174,8 @@ teardown() {
 
   # Entire tree exists under coverage root, but root must not trigger one --name monorepo-root --flag monorepo-root upload.
   CODECOV_TOKEN='' \
+  CODECOV_FAIL_ON_ERROR=false \
+  CODECOV_VERBOSE=false \
   MONOREPO_ROOT="$TEST_DIR" \
   COVERAGE_DIR="$COVERAGE_DIR" \
   CODECOV_BINARY="${codecov_mock}" \
@@ -165,4 +185,36 @@ teardown() {
   assert_success
   assert_output --partial "Skipping coverage upload for nx-plugin-e2e because $COVERAGE_DIR/e2e/nx-plugin-e2e does not exist"
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 1
+}
+
+@test "fails when no package coverage reports are uploaded by default" {
+  rm -rf "$COVERAGE_DIR"/packages/nx-plugin "$COVERAGE_DIR"/e2e/nx-plugin-e2e
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_failure
+  assert_output --partial "ERROR: no coverage reports were uploaded."
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 0
+}
+
+@test "allows empty uploads when CODECOV_REQUIRE_UPLOADS is false" {
+  rm -rf "$COVERAGE_DIR"/packages/nx-plugin "$COVERAGE_DIR"/e2e/nx-plugin-e2e
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  CODECOV_REQUIRE_UPLOADS=false \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 0
 }

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -143,6 +143,7 @@ teardown() {
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
   assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e --fail-on-error --verbose"
 }
 
 @test "skips workspace root package; does not upload full coverage tree under root name" {


### PR DESCRIPTION
## Summary
- default monorepo Codecov uploads to `fail-on-error: true` and `verbose: true` so uploader/API problems fail CI with actionable logs
- add `require-uploads` (default `true`) so the job fails when zero per-package coverage uploads occur, with explicit opt-out for expected empty runs
- add a separate patch changeset for this hardening and extend bats coverage for default flags, no-upload failure, and opt-out behavior

## Test plan
- [x] `pnpm exec bats test/uploadMonorepoCoverageWithCodecovCli.bats`
- [x] `pnpm lint:scripts`
- [x] `pnpm lint:yml`

Made with [Cursor](https://cursor.com)