### PR TITLE
fix(codecov): prefer unscoped package flags with scoped fallback

### DIFF
--- a/.changeset/fuzzy-tools-juggle.md
+++ b/.changeset/fuzzy-tools-juggle.md
@@ -4,4 +4,4 @@
 
 Normalize monorepo package-derived Codecov flags to valid Codecov flag names.
 
-Scoped package names now upload with normalized flags (for example `@chiubaka/lint` becomes `chiubaka-lint`) so monorepo coverage uploads do not fail on invalid flag characters. If your `codecov.yml` uses `individual_flags`, update names to the normalized values used by uploads.
+Scoped package names now default to the post-scope segment for Codecov flags (for example `@chiubaka/lint` becomes `lint`) so monorepo coverage uploads align with package identities. When unscoped names collide, uploads fall back to a scope-prefixed flag only if it resolves the collision; unresolved collisions now fail loudly so you can fix naming deterministically.

--- a/src/commands/upload-monorepo-coverage.yml
+++ b/src/commands/upload-monorepo-coverage.yml
@@ -5,7 +5,7 @@ description: >
   root `package.json` name is not used as a Codecov flag. Leaf packages under the workspace
   continue to receive one upload each when their per-package coverage directory exists. Package
   names are normalized to Codecov-safe flags (for example `@chiubaka/lint` becomes
-  `chiubaka-lint`) before upload.
+  `lint`) before upload.
 
 parameters:
   app-dir:

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -75,6 +75,11 @@ resolve_unique_flag() {
   fi
 
   scoped_flag="$(sanitize_package_flag "$package_with_scope")"
+  if [[ "$scoped_flag" == "$unscoped_flag" ]]; then
+    echo "ERROR: unable to derive unique Codecov flag for package $package_name. Unscoped candidate '$unscoped_flag' collides with ${flag_to_package[$unscoped_flag]}, and no distinct scoped fallback is available." >&2
+    exit 1
+  fi
+
   existing_package="${flag_to_package[$scoped_flag]-}"
   if [[ -z "$existing_package" ]] || [[ "$existing_package" == "$package_name" ]]; then
     printf '%s' "$scoped_flag"

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -45,10 +45,10 @@ IFS=',' read -r -a configured_files <<< "${CODECOV_FILES:-}"
 IFS=',' read -r -a configured_flags <<< "${CODECOV_FLAGS:-}"
 
 sanitize_package_flag() {
-  local package_name="$1"
+  local raw_name="$1"
   local sanitized
 
-  sanitized="${package_name#@}"
+  sanitized="$raw_name"
   sanitized="${sanitized//\//-}"
   sanitized="$(printf '%s' "$sanitized" | sed -E 's/[^[:alnum:]_.-]+/-/g; s/-+/-/g; s/^[._-]+//; s/[._-]+$//')"
   sanitized="${sanitized:0:45}"
@@ -61,63 +61,28 @@ sanitize_package_flag() {
   printf '%s' "$sanitized"
 }
 
-short_hash() {
-  local input="$1"
-
-  if command -v sha256sum >/dev/null 2>&1; then
-    printf '%s' "$input" | sha256sum | cut -c1-8
-    return
-  fi
-
-  if command -v shasum >/dev/null 2>&1; then
-    printf '%s' "$input" | shasum -a 256 | cut -c1-8
-    return
-  fi
-
-  echo "ERROR: neither sha256sum nor shasum is available for flag collision handling." >&2
-  exit 1
-}
-
 resolve_unique_flag() {
   local package_name="$1"
-  local base_flag="$2"
-  local existing_package
-  local hashed_flag hash_suffix hash base_limit truncated_base
+  local package_without_scope="$2"
+  local package_with_scope="$3"
+  local unscoped_flag scoped_flag existing_package
 
-  existing_package="${flag_to_package[$base_flag]-}"
-  if [[ -z "$existing_package" ]]; then
-    printf '%s' "$base_flag"
+  unscoped_flag="$(sanitize_package_flag "$package_without_scope")"
+  existing_package="${flag_to_package[$unscoped_flag]-}"
+  if [[ -z "$existing_package" ]] || [[ "$existing_package" == "$package_name" ]]; then
+    printf '%s' "$unscoped_flag"
     return
   fi
 
-  if [[ "$existing_package" == "$package_name" ]]; then
-    printf '%s' "$base_flag"
+  scoped_flag="$(sanitize_package_flag "$package_with_scope")"
+  existing_package="${flag_to_package[$scoped_flag]-}"
+  if [[ -z "$existing_package" ]] || [[ "$existing_package" == "$package_name" ]]; then
+    printf '%s' "$scoped_flag"
     return
   fi
 
-  hash="$(short_hash "$package_name")"
-  hash_suffix="-$hash"
-  base_limit=$((45 - ${#hash_suffix}))
-
-  if (( base_limit < 1 )); then
-    echo "ERROR: unable to derive unique Codecov flag for package $package_name." >&2
-    exit 1
-  fi
-
-  truncated_base="${base_flag:0:$base_limit}"
-  truncated_base="$(printf '%s' "$truncated_base" | sed -E 's/[._-]+$//')"
-  if [[ -z "$truncated_base" ]]; then
-    truncated_base="pkg"
-  fi
-  hashed_flag="${truncated_base}${hash_suffix}"
-
-  existing_package="${flag_to_package[$hashed_flag]-}"
-  if [[ -n "$existing_package" ]] && [[ "$existing_package" != "$package_name" ]]; then
-    echo "ERROR: flag collision detected after sanitization: $package_name and $existing_package both map to $hashed_flag." >&2
-    exit 1
-  fi
-
-  printf '%s' "$hashed_flag"
+  echo "ERROR: unable to derive unique Codecov flag for package $package_name. Unscoped candidate '$unscoped_flag' collides with ${flag_to_package[$unscoped_flag]}, and scoped candidate '$scoped_flag' collides with ${flag_to_package[$scoped_flag]}." >&2
+  exit 1
 }
 
 declare -A package_to_flag=()
@@ -151,8 +116,14 @@ while IFS=$'\t' read -r package_name package_abs_path; do
 
   package_flag="${package_to_flag[$package_name]-}"
   if [[ -z "$package_flag" ]]; then
-    base_flag="$(sanitize_package_flag "$package_name")"
-    package_flag="$(resolve_unique_flag "$package_name" "$base_flag")"
+    package_without_scope="$package_name"
+    package_with_scope="$package_name"
+    if [[ "$package_name" =~ ^@([^/]+)/(.+)$ ]]; then
+      package_without_scope="${BASH_REMATCH[2]}"
+      package_with_scope="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+    fi
+
+    package_flag="$(resolve_unique_flag "$package_name" "$package_without_scope" "$package_with_scope")"
     package_to_flag["$package_name"]="$package_flag"
     flag_to_package["$package_flag"]="$package_name"
   fi

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -51,8 +51,8 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/lint --flag chiubaka-lint --fail-on-error --verbose"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @chiubaka/e2e-tests --flag chiubaka-e2e-tests --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/lint --flag lint --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @chiubaka/e2e-tests --flag e2e-tests --fail-on-error --verbose"
 }
 
 @test "normalizes disallowed characters in package-derived flags" {
@@ -69,7 +69,7 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 1
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/pkg!!name --flag chiubaka-pkg-name --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/pkg!!name --flag pkg-name --fail-on-error --verbose"
 }
 
 @test "truncates long package-derived flags to Codecov max length" {
@@ -87,17 +87,13 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 1
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name $long_name --flag scope-abcdefghijklmnopqrstuvwxyz1234567890abc --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name $long_name --flag abcdefghijklmnopqrstuvwxyz1234567890abcdefghi --fail-on-error --verbose"
 }
 
-@test "adds hash suffix when sanitized flags collide" {
-  colliding_pnpm_ls_json="[{\"name\":\"@a/b\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"a-b\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
+@test "adds scope back when unscoped flag collides" {
+  colliding_pnpm_ls_json="[{\"name\":\"@a/pkg\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"@b/pkg\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
   mock_set_output "${pnpm_mock}" "$colliding_pnpm_ls_json"
   codecov_mock=$(mock_create)
-
-  run bash -lc "printf '%s' 'a-b' | sha256sum | cut -c1-8"
-  assert_success
-  hash_suffix="$output"
 
   CODECOV_TOKEN='' \
   MONOREPO_ROOT="$TEST_DIR" \
@@ -108,8 +104,44 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @a/b --flag a-b --fail-on-error --verbose"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name a-b --flag a-b-$hash_suffix --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @a/pkg --flag pkg --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @b/pkg --flag b-pkg --fail-on-error --verbose"
+}
+
+@test "resolves collisions introduced by 45-char truncation via scope fallback" {
+  long_leaf="abcdefghijklmnopqrstuvwxyz1234567890abcdefghijk"
+  colliding_pnpm_ls_json="[{\"name\":\"@alpha/$long_leaf\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"@beta/$long_leaf\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
+  mock_set_output "${pnpm_mock}" "$colliding_pnpm_ls_json"
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @alpha/$long_leaf --flag abcdefghijklmnopqrstuvwxyz1234567890abcdefghi --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @beta/$long_leaf --flag beta-abcdefghijklmnopqrstuvwxyz1234567890abcd --fail-on-error --verbose"
+}
+
+@test "fails loudly when unscoped and scoped candidates both collide" {
+  colliding_pnpm_ls_json="[{\"name\":\"@a/pkg\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"b-pkg\",\"path\":\"$TEST_DIR/extra/b-pkg\"},{\"name\":\"@b/pkg\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
+  mock_set_output "${pnpm_mock}" "$colliding_pnpm_ls_json"
+  mkdir -p "$COVERAGE_DIR"/extra/b-pkg
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_failure
+  assert_output --partial "ERROR: unable to derive unique Codecov flag for package @b/pkg. Unscoped candidate 'pkg' collides with @a/pkg, and scoped candidate 'b-pkg' collides with b-pkg."
 }
 
 @test "omits token and optional args when unset" {

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -144,6 +144,22 @@ teardown() {
   assert_output --partial "ERROR: unable to derive unique Codecov flag for package @b/pkg. Unscoped candidate 'pkg' collides with @a/pkg, and scoped candidate 'b-pkg' collides with b-pkg."
 }
 
+@test "fails with explicit no-fallback message for unscoped collision" {
+  colliding_pnpm_ls_json="[{\"name\":\"pkg\",\"path\":\"$TEST_DIR/packages/nx-plugin\"},{\"name\":\"pkg!\",\"path\":\"$TEST_DIR/e2e/nx-plugin-e2e\"}]"
+  mock_set_output "${pnpm_mock}" "$colliding_pnpm_ls_json"
+  codecov_mock=$(mock_create)
+
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  CODECOV_BINARY="${codecov_mock}" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_failure
+  assert_output --partial "ERROR: unable to derive unique Codecov flag for package pkg!. Unscoped candidate 'pkg' collides with pkg, and no distinct scoped fallback is available."
+}
+
 @test "omits token and optional args when unset" {
   codecov_mock=$(mock_create)
 


### PR DESCRIPTION
## Summary
- derive per-package Codecov flags from the unscoped package segment first (e.g. `@chiubaka/eslint-config` -> `eslint-config`)
- on collision, retry with a scope-prefixed candidate and keep that flag only when it resolves uniquely
- fail loudly when both unscoped and scoped candidates collide, and add Bats regression coverage including truncation-driven collisions

## Test plan
- [x] `pnpm test`

Made with [Cursor](https://cursor.com)