### PR TITLE
fix(codecov): monorepo upload via validated binary CLI

### DIFF
--- a/.changeset/fair-lions-learn.md
+++ b/.changeset/fair-lions-learn.md
@@ -2,6 +2,6 @@
 "@chiubaka/circleci-orb": patch
 ---
 
-Harden Codecov CLI installation when Python environments do not include the pip module.
+Install the Codecov CLI the same way as the official [codecov/codecov](https://circleci.com/orbs/registry/orb/codecov/codecov) orb: download the `codecov` binary from `https://cli.codecov.io` (per [codecov/wrapper](https://github.com/codecov/wrapper) `download.sh`), then verify with GPG and SHA256 (per `validate.sh`) unless `CODECOV_SKIP_VALIDATION` is set. Pip is no longer used.
 
-The monorepo coverage upload command now tries `python3 -m pip`, then `python3 -m ensurepip`, and finally `pip3` before failing with an actionable error. This avoids failing immediately on images that provide Python but omit `python3 -m pip`.
+`upload-monorepo-coverage` accepts `codecov-version`, `skip-codecov-cli-validation`, and an optional `codecov-cli-base-url` (`CODECOV_CLI_URL`). The default for `fail-on-error` is restored to `true`.

--- a/.changeset/fair-lions-learn.md
+++ b/.changeset/fair-lions-learn.md
@@ -1,0 +1,6 @@
+"@chiubaka/circleci-orb": patch
+---
+
+Harden Codecov CLI installation when Python environments do not include the pip module.
+
+The monorepo coverage upload command now tries `python3 -m pip`, then `python3 -m ensurepip`, and finally `pip3` before failing with an actionable error. This avoids failing immediately on images that provide Python but omit `python3 -m pip`.

--- a/.changeset/fair-lions-learn.md
+++ b/.changeset/fair-lions-learn.md
@@ -2,6 +2,8 @@
 "@chiubaka/circleci-orb": patch
 ---
 
-Install the Codecov CLI the same way as the official [codecov/codecov](https://circleci.com/orbs/registry/orb/codecov/codecov) orb: download the `codecov` binary from `https://cli.codecov.io` (per [codecov/wrapper](https://github.com/codecov/wrapper) `download.sh`), then verify with GPG and SHA256 (per `validate.sh`) unless `CODECOV_SKIP_VALIDATION` is set. Pip is no longer used.
+Fix monorepo Codecov CLI install and upload invocation on minimal CI images.
 
-`upload-monorepo-coverage` accepts `codecov-version`, `skip-codecov-cli-validation`, and an optional `codecov-cli-base-url` (`CODECOV_CLI_URL`). The default for `fail-on-error` is restored to `true`.
+Replaces pip with the official `codecov` binary from `https://cli.codecov.io`, matching codecov/wrapper download and validate behavior (GPG + SHA256 unless `CODECOV_SKIP_VALIDATION` is set). `upload-monorepo-coverage` adds `codecov-version`, `skip-codecov-cli-validation`, and `codecov-cli-base-url`; `fail-on-error` defaults to `true`.
+
+Fixes two regressions encountered after switching to the binary: `sha256sum`/`shasum -c` printed `codecov: OK` to stdout, which Bash command substitution mixed into the resolved CLI path so the shell tried to run `codecov: OK`; checksum verification now silences stdout. Also passes verbosity as global `codecov -v` because `upload-coverage` on that binary does not accept `--verbose` (unlike older `codecovcli` usage).

--- a/.changeset/fair-lions-learn.md
+++ b/.changeset/fair-lions-learn.md
@@ -1,3 +1,4 @@
+---
 "@chiubaka/circleci-orb": patch
 ---
 

--- a/src/commands/upload-monorepo-coverage.yml
+++ b/src/commands/upload-monorepo-coverage.yml
@@ -24,8 +24,8 @@ parameters:
     description: Path relative to app-dir where coverage reports can be found
   fail-on-error:
     type: boolean
-    default: true
-    description: Exit non-zero when an upload fails (recommended default).
+    default: false
+    description: Exit non-zero when an upload fails.
   verbose:
     type: boolean
     default: true

--- a/src/commands/upload-monorepo-coverage.yml
+++ b/src/commands/upload-monorepo-coverage.yml
@@ -24,7 +24,7 @@ parameters:
     description: Path relative to app-dir where coverage reports can be found
   fail-on-error:
     type: boolean
-    default: false
+    default: true
     description: Exit non-zero when an upload fails.
   verbose:
     type: boolean
@@ -46,6 +46,18 @@ parameters:
     type: string
     default: ""
     description: Comma-separated list of additional Codecov flags for this upload.
+  codecov-version:
+    type: string
+    default: latest
+    description: Version segment for https://cli.codecov.io (same as codecov/codecov CODECOV_VERSION).
+  skip-codecov-cli-validation:
+    type: boolean
+    default: false
+    description: If true, skip GPG/SHA256 verification after downloading the Codecov CLI (not recommended; matches CODECOV_SKIP_VALIDATION in the official orb).
+  codecov-cli-base-url:
+    type: string
+    default: ""
+    description: Optional base URL for CLI downloads; empty uses https://cli.codecov.io (CODECOV_CLI_URL).
 
 steps:
   - run:
@@ -61,3 +73,6 @@ steps:
         CODECOV_REQUIRE_UPLOADS: << parameters.require-uploads >>
         CODECOV_FILES: << parameters.files >>
         CODECOV_FLAGS: << parameters.flags >>
+        CODECOV_VERSION: << parameters.codecov-version >>
+        CODECOV_SKIP_VALIDATION: << parameters.skip-codecov-cli-validation >>
+        CODECOV_CLI_URL: << parameters.codecov-cli-base-url >>

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -14,6 +14,11 @@ monorepo_root=$(pwd)
 coverage_root=${COVERAGE_DIR:?COVERAGE_DIR is required}
 pnpm_bin=${PNPM_BINARY:-pnpm}
 codecov_bin=${CODECOV_BINARY:-codecovcli}
+if [[ "${CODECOV_FAIL_ON_ERROR:-true}" == "true" ]] || [[ "${CODECOV_FAIL_ON_ERROR:-1}" == "1" ]]; then
+  fail_on_error=true
+else
+  fail_on_error=false
+fi
 
 install_codecov_cli() {
   local bootstrap_dir bootstrap_script
@@ -54,24 +59,34 @@ install_codecov_cli() {
   fi
   rm -rf "$bootstrap_dir"
 
-  echo "ERROR: codecovcli is not available and no Python pip installer could be bootstrapped. Install pip for python3 or provide a preinstalled Codecov binary via CODECOV_BINARY." >&2
-  exit 1
+  return 1
 }
 
 # Install Codecov CLI if no preinstalled binary is provided.
 if ! command -v "$codecov_bin" >/dev/null 2>&1; then
   if ! command -v python3 >/dev/null 2>&1; then
-    echo "ERROR: codecovcli is not available and python3 is not installed." >&2
-    exit 1
+    if [[ "$fail_on_error" == "true" ]]; then
+      echo "ERROR: codecovcli is not available and python3 is not installed." >&2
+      exit 1
+    fi
+    echo "WARNING: codecovcli is unavailable, python3 is not installed, and CODECOV_FAIL_ON_ERROR is disabled. Skipping coverage upload." >&2
+    exit 0
   fi
 
-  install_codecov_cli
+  if ! install_codecov_cli; then
+    if [[ "$fail_on_error" == "true" ]]; then
+      echo "ERROR: codecovcli is not available and no Python pip installer could be bootstrapped. Install pip for python3 or provide a preinstalled Codecov binary via CODECOV_BINARY." >&2
+      exit 1
+    fi
+    echo "WARNING: codecovcli is not available and no Python pip installer could be bootstrapped, but CODECOV_FAIL_ON_ERROR is disabled. Skipping coverage upload." >&2
+    exit 0
+  fi
   export PATH="$HOME/.local/bin:$PATH"
   codecov_bin=codecovcli
 fi
 
 common_args=()
-if [[ "${CODECOV_FAIL_ON_ERROR:-true}" == "true" ]] || [[ "${CODECOV_FAIL_ON_ERROR:-1}" == "1" ]]; then
+if [[ "$fail_on_error" == "true" ]]; then
   common_args+=(--fail-on-error)
 fi
 if [[ "${CODECOV_VERBOSE:-true}" == "true" ]] || [[ "${CODECOV_VERBOSE:-1}" == "1" ]]; then

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -1,4 +1,6 @@
 #! /usr/bin/env bash
+# Install and run the Codecov CLI the same way as codecov/codecov: binary from cli.codecov.io
+# (see https://github.com/codecov/wrapper scripts/download.sh and validate.sh), not via pip.
 set -euo pipefail
 
 # Keep parity with Codecov orb behavior for Node-based environments.
@@ -13,76 +15,151 @@ monorepo_root=$(pwd)
 
 coverage_root=${COVERAGE_DIR:?COVERAGE_DIR is required}
 pnpm_bin=${PNPM_BINARY:-pnpm}
-codecov_bin=${CODECOV_BINARY:-codecovcli}
+curl_retry=(--retry 5 --retry-delay 2)
+
+codecov_detect_os() {
+  if [[ -n "${CODECOV_OS:-}" ]]; then
+    printf '%s' "$CODECOV_OS"
+    return
+  fi
+  # Same OS labels as https://github.com/codecov/wrapper/blob/main/scripts/download.sh
+  local family os_id arch
+  family=$(uname -s | tr '[:upper:]' '[:lower:]')
+  arch=$(arch 2>/dev/null || uname -m)
+  if [[ $family == "darwin" ]]; then
+    printf '%s' "macos"
+    return
+  fi
+  if [[ $family != "linux" ]]; then
+    printf '%s' "linux"
+    return
+  fi
+  if [[ -r /etc/os-release ]]; then
+    os_id=$(grep -E '^ID=' /etc/os-release | cut -c4-)
+    if [[ $os_id == "alpine" ]]; then
+      if [[ $arch == "aarch64" ]]; then
+        printf '%s' "alpine-arm64"
+      else
+        printf '%s' "alpine"
+      fi
+      return
+    fi
+  fi
+  if [[ $arch == "aarch64" ]]; then
+    printf '%s' "linux-arm64"
+  else
+    printf '%s' "linux"
+  fi
+}
+
+codecov_validate_cli() {
+  # Mirrors https://github.com/codecov/wrapper/blob/main/scripts/validate.sh
+  local install_dir="$1"
+  local filename="$2"
+
+  if [[ "${CODECOV_SKIP_VALIDATION:-false}" == "true" ]] || [[ "${CODECOV_SKIP_VALIDATION:-0}" == "1" ]]; then
+    echo "(Codecov) Skipping CLI integrity validation" >&2
+    chmod +x "$install_dir/$filename"
+    return
+  fi
+
+  if ! command -v gpg >/dev/null 2>&1; then
+    echo "ERROR: gpg is not installed. Install gnupg (e.g. apt install gnupg) or set CODECOV_SKIP_VALIDATION=true" >&2
+    return 1
+  fi
+
+  if ! (
+    cd "$install_dir" || exit 1
+    curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --import
+    local base sha_url
+    base="${CODECOV_CLI_URL:-https://cli.codecov.io}"
+    base="${base}/${CODECOV_VERSION:-latest}/${CODECOV_OS?}"
+    sha_url="${base}/${filename}.SHA256SUM"
+    curl -fsS "${curl_retry[@]}" --connect-timeout 2 -O "$sha_url"
+    curl -fsS "${curl_retry[@]}" --connect-timeout 2 -O "${sha_url}.sig"
+    if ! gpg --verify "${filename}.SHA256SUM.sig" "${filename}.SHA256SUM"; then
+      echo "ERROR: could not verify GPG signature of Codecov CLI checksum" >&2
+      exit 1
+    fi
+    if ! (shasum -a 256 -c "${filename}.SHA256SUM" 2>/dev/null || sha256sum -c "${filename}.SHA256SUM"); then
+      echo "ERROR: could not verify SHA256 of Codecov CLI" >&2
+      exit 1
+    fi
+    chmod +x "$filename"
+  ); then
+    return 1
+  fi
+  echo "Codecov CLI integrity verified" >&2
+}
+
+download_codecov_cli() {
+  if ! command -v curl >/dev/null 2>&1; then
+    echo "ERROR: curl is not installed. The Codecov CLI is downloaded with curl; install curl or set CODECOV_BINARY to a preinstalled codecov binary path." >&2
+    return 1
+  fi
+
+  local install_dir base_url download_url
+  local codecov_filename=codecov
+
+  export CODECOV_VERSION="${CODECOV_VERSION:-latest}"
+  CODECOV_OS=$(codecov_detect_os)
+  export CODECOV_OS
+  install_dir=$(mktemp -d)
+  base_url="${CODECOV_CLI_URL:-https://cli.codecov.io}"
+  base_url="${base_url}/${CODECOV_VERSION}/${CODECOV_OS}"
+  download_url="${base_url}/${codecov_filename}"
+
+  echo "Downloading Codecov CLI from $download_url" >&2
+  if ! curl -fsSL "${curl_retry[@]}" "$download_url" -o "$install_dir/${codecov_filename}"; then
+    echo "ERROR: failed to download Codecov CLI from $download_url" >&2
+    rm -rf "$install_dir"
+    return 1
+  fi
+
+  if ! codecov_validate_cli "$install_dir" "$codecov_filename"; then
+    rm -rf "$install_dir"
+    return 1
+  fi
+
+  printf '%s' "$install_dir/${codecov_filename}"
+}
+
+resolve_codecov_command() {
+  # Preinstalled path: CODECOV_BINARY (same as codecov/codecov)
+  if [[ -n "${CODECOV_BINARY:-}" ]] && [[ -f "$CODECOV_BINARY" ]]; then
+    if [[ -x "$CODECOV_BINARY" ]]; then
+      printf '%s' "$CODECOV_BINARY"
+      return
+    fi
+    echo "ERROR: CODECOV_BINARY is not an executable file: $CODECOV_BINARY" >&2
+    return 1
+  fi
+  # PATH: official download installs as "codecov"; PyPI has "codecovcli"
+  local n=${CODECOV_BINARY:-}
+  if [[ -z "$n" ]]; then
+    if command -v codecov >/dev/null 2>&1; then
+      command -v codecov
+      return
+    fi
+    if command -v codecovcli >/dev/null 2>&1; then
+      command -v codecovcli
+      return
+    fi
+  elif command -v "$n" >/dev/null 2>&1; then
+    command -v "$n"
+    return
+  fi
+  download_codecov_cli
+}
+
+if ! codecov_cmd=$(resolve_codecov_command); then
+  exit 1
+fi
+
 if [[ "${CODECOV_FAIL_ON_ERROR:-true}" == "true" ]] || [[ "${CODECOV_FAIL_ON_ERROR:-1}" == "1" ]]; then
   fail_on_error=true
 else
   fail_on_error=false
-fi
-
-install_codecov_cli() {
-  local bootstrap_dir bootstrap_script
-  local get_pip_url="https://bootstrap.pypa.io/get-pip.py"
-
-  if python3 -m pip --version >/dev/null 2>&1; then
-    if python3 -m pip install --user codecov-cli >/dev/null; then
-      return
-    fi
-  fi
-
-  if python3 -m ensurepip --upgrade --user >/dev/null 2>&1 && python3 -m pip --version >/dev/null 2>&1; then
-    if python3 -m pip install --user codecov-cli >/dev/null; then
-      return
-    fi
-  fi
-
-  if command -v pip3 >/dev/null 2>&1; then
-    if pip3 install --user codecov-cli >/dev/null; then
-      return
-    fi
-  fi
-
-  bootstrap_dir="$(mktemp -d)"
-  bootstrap_script="$bootstrap_dir/get-pip.py"
-  if command -v curl >/dev/null 2>&1; then
-    curl -fsSL "$get_pip_url" -o "$bootstrap_script" >/dev/null 2>&1 || true
-  fi
-  if [[ ! -s "$bootstrap_script" ]] && command -v wget >/dev/null 2>&1; then
-    wget -qO "$bootstrap_script" "$get_pip_url" >/dev/null 2>&1 || true
-  fi
-
-  if [[ -s "$bootstrap_script" ]] && python3 "$bootstrap_script" --user >/dev/null 2>&1; then
-    if python3 -m pip install --user codecov-cli >/dev/null; then
-      rm -rf "$bootstrap_dir"
-      return
-    fi
-  fi
-  rm -rf "$bootstrap_dir"
-
-  return 1
-}
-
-# Install Codecov CLI if no preinstalled binary is provided.
-if ! command -v "$codecov_bin" >/dev/null 2>&1; then
-  if ! command -v python3 >/dev/null 2>&1; then
-    if [[ "$fail_on_error" == "true" ]]; then
-      echo "ERROR: codecovcli is not available and python3 is not installed." >&2
-      exit 1
-    fi
-    echo "WARNING: codecovcli is unavailable, python3 is not installed, and CODECOV_FAIL_ON_ERROR is disabled. Skipping coverage upload." >&2
-    exit 0
-  fi
-
-  if ! install_codecov_cli; then
-    if [[ "$fail_on_error" == "true" ]]; then
-      echo "ERROR: codecovcli is not available and no Python pip installer could be bootstrapped. Install pip for python3 or provide a preinstalled Codecov binary via CODECOV_BINARY." >&2
-      exit 1
-    fi
-    echo "WARNING: codecovcli is not available and no Python pip installer could be bootstrapped, but CODECOV_FAIL_ON_ERROR is disabled. Skipping coverage upload." >&2
-    exit 0
-  fi
-  export PATH="$HOME/.local/bin:$PATH"
-  codecov_bin=codecovcli
 fi
 
 common_args=()
@@ -218,7 +295,7 @@ while IFS=$'\t' read -r package_name package_abs_path; do
     fi
   done
 
-  "$codecov_bin" "${upload_args[@]}"
+  "$codecov_cmd" "${upload_args[@]}"
   upload_count=$((upload_count + 1))
 done < <($pnpm_bin ls --json -r 2>/dev/null | jq -r '.[] | "\(.name)\t\(.path)"')
 

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -17,6 +17,7 @@ codecov_bin=${CODECOV_BINARY:-codecovcli}
 
 install_codecov_cli() {
   local bootstrap_dir bootstrap_script
+  local get_pip_url="https://bootstrap.pypa.io/get-pip.py"
 
   if python3 -m pip --version >/dev/null 2>&1; then
     if python3 -m pip install --user codecov-cli >/dev/null; then
@@ -36,17 +37,22 @@ install_codecov_cli() {
     fi
   fi
 
+  bootstrap_dir="$(mktemp -d)"
+  bootstrap_script="$bootstrap_dir/get-pip.py"
   if command -v curl >/dev/null 2>&1; then
-    bootstrap_dir="$(mktemp -d)"
-    bootstrap_script="$bootstrap_dir/get-pip.py"
-    if curl -fsSL https://bootstrap.pypa.io/get-pip.py -o "$bootstrap_script" >/dev/null 2>&1 && python3 "$bootstrap_script" --user >/dev/null 2>&1; then
-      if python3 -m pip install --user codecov-cli >/dev/null; then
-        rm -rf "$bootstrap_dir"
-        return
-      fi
-    fi
-    rm -rf "$bootstrap_dir"
+    curl -fsSL "$get_pip_url" -o "$bootstrap_script" >/dev/null 2>&1 || true
   fi
+  if [[ ! -s "$bootstrap_script" ]] && command -v wget >/dev/null 2>&1; then
+    wget -qO "$bootstrap_script" "$get_pip_url" >/dev/null 2>&1 || true
+  fi
+
+  if [[ -s "$bootstrap_script" ]] && python3 "$bootstrap_script" --user >/dev/null 2>&1; then
+    if python3 -m pip install --user codecov-cli >/dev/null; then
+      rm -rf "$bootstrap_dir"
+      return
+    fi
+  fi
+  rm -rf "$bootstrap_dir"
 
   echo "ERROR: codecovcli is not available and no Python pip installer could be bootstrapped. Install pip for python3 or provide a preinstalled Codecov binary via CODECOV_BINARY." >&2
   exit 1

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -166,8 +166,11 @@ common_args=()
 if [[ "$fail_on_error" == "true" ]]; then
   common_args+=(--fail-on-error)
 fi
+global_args=()
 if [[ "${CODECOV_VERBOSE:-true}" == "true" ]] || [[ "${CODECOV_VERBOSE:-1}" == "1" ]]; then
-  common_args+=(--verbose)
+  # For codecov binary installs, verbosity is a global option (`codecov -v ...`),
+  # not an `upload-coverage` subcommand option.
+  global_args+=(-v)
 fi
 if [[ "${CODECOV_DISABLE_SEARCH:-false}" == "true" ]] || [[ "${CODECOV_DISABLE_SEARCH:-0}" == "1" ]]; then
   common_args+=(--disable-search)
@@ -295,7 +298,7 @@ while IFS=$'\t' read -r package_name package_abs_path; do
     fi
   done
 
-  "$codecov_cmd" "${upload_args[@]}"
+  "$codecov_cmd" "${global_args[@]}" "${upload_args[@]}"
   upload_count=$((upload_count + 1))
 done < <($pnpm_bin ls --json -r 2>/dev/null | jq -r '.[] | "\(.name)\t\(.path)"')
 

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -15,6 +15,29 @@ coverage_root=${COVERAGE_DIR:?COVERAGE_DIR is required}
 pnpm_bin=${PNPM_BINARY:-pnpm}
 codecov_bin=${CODECOV_BINARY:-codecovcli}
 
+install_codecov_cli() {
+  if python3 -m pip --version >/dev/null 2>&1; then
+    if python3 -m pip install --user codecov-cli >/dev/null; then
+      return
+    fi
+  fi
+
+  if python3 -m ensurepip --upgrade --user >/dev/null 2>&1 && python3 -m pip --version >/dev/null 2>&1; then
+    if python3 -m pip install --user codecov-cli >/dev/null; then
+      return
+    fi
+  fi
+
+  if command -v pip3 >/dev/null 2>&1; then
+    if pip3 install --user codecov-cli >/dev/null; then
+      return
+    fi
+  fi
+
+  echo "ERROR: codecovcli is not available and no Python pip installer was found. Install pip for python3 or provide a preinstalled Codecov binary via CODECOV_BINARY." >&2
+  exit 1
+}
+
 # Install Codecov CLI if no preinstalled binary is provided.
 if ! command -v "$codecov_bin" >/dev/null 2>&1; then
   if ! command -v python3 >/dev/null 2>&1; then
@@ -22,7 +45,7 @@ if ! command -v "$codecov_bin" >/dev/null 2>&1; then
     exit 1
   fi
 
-  python3 -m pip install --user codecov-cli >/dev/null
+  install_codecov_cli
   export PATH="$HOME/.local/bin:$PATH"
   codecov_bin=codecovcli
 fi

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -81,7 +81,7 @@ codecov_validate_cli() {
       echo "ERROR: could not verify GPG signature of Codecov CLI checksum" >&2
       exit 1
     fi
-    if ! (shasum -a 256 -c "${filename}.SHA256SUM" 2>/dev/null || sha256sum -c "${filename}.SHA256SUM"); then
+    if ! (shasum -a 256 -c "${filename}.SHA256SUM" >/dev/null 2>&1 || sha256sum -c "${filename}.SHA256SUM" >/dev/null 2>&1); then
       echo "ERROR: could not verify SHA256 of Codecov CLI" >&2
       exit 1
     fi

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -16,6 +16,8 @@ pnpm_bin=${PNPM_BINARY:-pnpm}
 codecov_bin=${CODECOV_BINARY:-codecovcli}
 
 install_codecov_cli() {
+  local bootstrap_dir bootstrap_script
+
   if python3 -m pip --version >/dev/null 2>&1; then
     if python3 -m pip install --user codecov-cli >/dev/null; then
       return
@@ -34,7 +36,19 @@ install_codecov_cli() {
     fi
   fi
 
-  echo "ERROR: codecovcli is not available and no Python pip installer was found. Install pip for python3 or provide a preinstalled Codecov binary via CODECOV_BINARY." >&2
+  if command -v curl >/dev/null 2>&1; then
+    bootstrap_dir="$(mktemp -d)"
+    bootstrap_script="$bootstrap_dir/get-pip.py"
+    if curl -fsSL https://bootstrap.pypa.io/get-pip.py -o "$bootstrap_script" >/dev/null 2>&1 && python3 "$bootstrap_script" --user >/dev/null 2>&1; then
+      if python3 -m pip install --user codecov-cli >/dev/null; then
+        rm -rf "$bootstrap_dir"
+        return
+      fi
+    fi
+    rm -rf "$bootstrap_dir"
+  fi
+
+  echo "ERROR: codecovcli is not available and no Python pip installer could be bootstrapped. Install pip for python3 or provide a preinstalled Codecov binary via CODECOV_BINARY." >&2
   exit 1
 }
 

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -358,12 +358,87 @@ EOF
 #! /usr/bin/env bash
 if [[ "$1" == "-fsSL" && "$2" == "https://bootstrap.pypa.io/get-pip.py" && "$3" == "-o" ]]; then
   mkdir -p "$(dirname "$4")"
-  touch "$4"
+  printf '# bootstrap\n' >"$4"
   exit 0
 fi
 exit 1
 EOF
   chmod +x "$mock_bin_dir/curl"
+  cat >"$mock_bin_dir/pip3" <<'EOF'
+#! /usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/pip3"
+
+  HOME="$home_dir" \
+  PATH="$mock_bin_dir:$PATH" \
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_file_exist "$home_dir/.local/bin/codecovcli"
+  assert_output --partial "Uploading coverage for package nx-plugin"
+
+  rm -rf "$home_dir" "$mock_bin_dir"
+}
+
+@test "bootstraps pip with get-pip.py via wget when curl is unavailable" {
+  home_dir="$(mktemp -d)"
+  mock_bin_dir="$(mktemp -d)"
+  mkdir -p "$home_dir/.local/bin"
+
+  cat >"$mock_bin_dir/python3" <<'EOF'
+#! /usr/bin/env bash
+if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "--version" ]]; then
+  if [[ -f "$HOME/.get-pip-ready" ]]; then
+    exit 0
+  fi
+  exit 1
+fi
+
+if [[ "$1" == "-m" && "$2" == "ensurepip" ]]; then
+  exit 1
+fi
+
+if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "install" ]]; then
+  mkdir -p "$HOME/.local/bin"
+  cat >"$HOME/.local/bin/codecovcli" <<'INNER'
+#! /usr/bin/env bash
+printf '%s\n' "$*" >>"$HOME/codecov-invocations.log"
+INNER
+  chmod +x "$HOME/.local/bin/codecovcli"
+  exit 0
+fi
+
+if [[ "$1" == */get-pip.py && "$2" == "--user" ]]; then
+  touch "$HOME/.get-pip-ready"
+  exit 0
+fi
+
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/python3"
+
+  cat >"$mock_bin_dir/curl" <<'EOF'
+#! /usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/curl"
+
+  cat >"$mock_bin_dir/wget" <<'EOF'
+#! /usr/bin/env bash
+if [[ "$1" == "-qO" ]]; then
+  mkdir -p "$(dirname "$2")"
+  printf '# bootstrap\n' >"$2"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/wget"
+
   cat >"$mock_bin_dir/pip3" <<'EOF'
 #! /usr/bin/env bash
 exit 1

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -267,3 +267,81 @@ teardown() {
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 0
 }
+
+@test "bootstraps pip with ensurepip when python3 -m pip is unavailable" {
+  home_dir="$(mktemp -d)"
+  mock_bin_dir="$(mktemp -d)"
+  mkdir -p "$home_dir/.local/bin"
+
+  cat >"$mock_bin_dir/python3" <<'EOF'
+#! /usr/bin/env bash
+if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "--version" ]]; then
+  if [[ -f "$HOME/.ensurepip-ready" ]]; then
+    exit 0
+  fi
+  exit 1
+fi
+
+if [[ "$1" == "-m" && "$2" == "ensurepip" ]]; then
+  mkdir -p "$HOME/.local/bin"
+  touch "$HOME/.ensurepip-ready"
+  exit 0
+fi
+
+if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "install" ]]; then
+  mkdir -p "$HOME/.local/bin"
+  cat >"$HOME/.local/bin/codecovcli" <<'INNER'
+#! /usr/bin/env bash
+printf '%s\n' "$*" >>"$HOME/codecov-invocations.log"
+INNER
+  chmod +x "$HOME/.local/bin/codecovcli"
+  exit 0
+fi
+
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/python3"
+
+  HOME="$home_dir" \
+  PATH="$mock_bin_dir:$PATH" \
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_file_exist "$home_dir/.local/bin/codecovcli"
+  assert_output --partial "Uploading coverage for package nx-plugin"
+
+  rm -rf "$home_dir" "$mock_bin_dir"
+}
+
+@test "fails with actionable error when no pip installation path exists" {
+  home_dir="$(mktemp -d)"
+  mock_bin_dir="$(mktemp -d)"
+
+  cat >"$mock_bin_dir/python3" <<'EOF'
+#! /usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/python3"
+  cat >"$mock_bin_dir/pip3" <<'EOF'
+#! /usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/pip3"
+
+  HOME="$home_dir" \
+  PATH="$mock_bin_dir:$PATH" \
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_failure
+  assert_output --partial "ERROR: codecovcli is not available and no Python pip installer was found."
+
+  rm -rf "$home_dir" "$mock_bin_dir"
+}

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -387,3 +387,67 @@ EOF
 
   rm -rf "$tools_dir"
 }
+
+@test "ignores checksum stdout so resolved codecov command stays executable path" {
+  mock_bin_dir="$(mktemp -d)"
+  run_home="$(mktemp -d)"
+  ln -sfn "$(command -v jq)" "$mock_bin_dir/jq"
+  ln -sfn "$(command -v mktemp)" "$mock_bin_dir/mktemp"
+  ln -sfn "$(command -v rm)" "$mock_bin_dir/rm"
+  ln -sfn "$(command -v uname)" "$mock_bin_dir/uname"
+  ln -sfn "$(command -v tr)" "$mock_bin_dir/tr"
+  ln -sfn "$(command -v grep)" "$mock_bin_dir/grep"
+  ln -sfn "$(command -v cut)" "$mock_bin_dir/cut"
+
+  cat >"$mock_bin_dir/curl" <<'EOF'
+#! /usr/bin/env bash
+last="${@: -1}"
+if [[ "$1" == "-s" && "$2" == "https://keybase.io/codecovsecurity/pgp_keys.asc" ]]; then
+  printf 'fake-key'
+  exit 0
+fi
+if [[ "$*" == *" -o "* ]] && [[ "$last" == */codecov ]]; then
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf 'printf "codecov-ran\n"\n'
+  } >"$last"
+  chmod +x "$last"
+  exit 0
+fi
+if [[ "$*" == *" -O "* ]]; then
+  printf 'fake' >"$(basename "$last")"
+  exit 0
+fi
+exit 0
+EOF
+  chmod +x "$mock_bin_dir/curl"
+
+  cat >"$mock_bin_dir/gpg" <<'EOF'
+#! /usr/bin/env bash
+exit 0
+EOF
+  chmod +x "$mock_bin_dir/gpg"
+
+  cat >"$mock_bin_dir/shasum" <<'EOF'
+#! /usr/bin/env bash
+printf 'codecov: OK\n'
+exit 0
+EOF
+  chmod +x "$mock_bin_dir/shasum"
+
+  HOME="$run_home" \
+  CODECOV_TOKEN='' \
+  CODECOV_SKIP_VALIDATION=false \
+  PATH="$mock_bin_dir:$PROJECT_ROOT/src/scripts:$PATH" \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_output --partial "Codecov CLI integrity verified"
+  assert_output --partial "Uploading coverage for package nx-plugin"
+  assert_output --partial "codecov-ran"
+
+  rm -rf "$mock_bin_dir" "$run_home"
+}

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -33,8 +33,8 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin --fail-on-error --verbose --disable-search --file coverage.xml --file coverage-final.json --flag unit --flag monorepo"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e --fail-on-error --verbose --disable-search --file coverage.xml --file coverage-final.json --flag unit --flag monorepo"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "-v upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin --fail-on-error --disable-search --file coverage.xml --file coverage-final.json --flag unit --flag monorepo"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "-v upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e --fail-on-error --disable-search --file coverage.xml --file coverage-final.json --flag unit --flag monorepo"
 }
 
 @test "sanitizes scoped package names into Codecov-safe flags" {
@@ -51,8 +51,8 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/lint --flag lint --fail-on-error --verbose"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @chiubaka/e2e-tests --flag e2e-tests --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "-v upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/lint --flag lint --fail-on-error"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "-v upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @chiubaka/e2e-tests --flag e2e-tests --fail-on-error"
 }
 
 @test "normalizes disallowed characters in package-derived flags" {
@@ -69,7 +69,7 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 1
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/pkg!!name --flag pkg-name --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "-v upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @chiubaka/pkg!!name --flag pkg-name --fail-on-error"
 }
 
 @test "truncates long package-derived flags to Codecov max length" {
@@ -87,7 +87,7 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 1
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name $long_name --flag abcdefghijklmnopqrstuvwxyz1234567890abcdefghi --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "-v upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name $long_name --flag abcdefghijklmnopqrstuvwxyz1234567890abcdefghi --fail-on-error"
 }
 
 @test "adds scope back when unscoped flag collides" {
@@ -104,8 +104,8 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @a/pkg --flag pkg --fail-on-error --verbose"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @b/pkg --flag b-pkg --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "-v upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @a/pkg --flag pkg --fail-on-error"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "-v upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @b/pkg --flag b-pkg --fail-on-error"
 }
 
 @test "resolves collisions introduced by 45-char truncation via scope fallback" {
@@ -123,8 +123,8 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @alpha/$long_leaf --flag abcdefghijklmnopqrstuvwxyz1234567890abcdefghi --fail-on-error --verbose"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @beta/$long_leaf --flag beta-abcdefghijklmnopqrstuvwxyz1234567890abcd --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "-v upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name @alpha/$long_leaf --flag abcdefghijklmnopqrstuvwxyz1234567890abcdefghi --fail-on-error"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "-v upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name @beta/$long_leaf --flag beta-abcdefghijklmnopqrstuvwxyz1234567890abcd --fail-on-error"
 }
 
 @test "fails loudly when unscoped and scoped candidates both collide" {
@@ -190,8 +190,8 @@ teardown() {
 
   assert_success
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin --fail-on-error --verbose"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "-v upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin --fail-on-error"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "-v upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e --fail-on-error"
 }
 
 @test "skips workspace root package; does not upload full coverage tree under root name" {
@@ -213,8 +213,8 @@ teardown() {
   assert_success
   assert_output --partial "Skipping coverage upload for workspace root package monorepo-root; per-package subdirectories only"
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 2
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin --fail-on-error --verbose"
-  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e --fail-on-error --verbose"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 1)" "-v upload-coverage --dir $COVERAGE_DIR/packages/nx-plugin --network-root-folder $TEST_DIR --name nx-plugin --flag nx-plugin --fail-on-error"
+  assert_equal "$(mock_get_call_args "${codecov_mock}" 2)" "-v upload-coverage --dir $COVERAGE_DIR/e2e/nx-plugin-e2e --network-root-folder $TEST_DIR --name nx-plugin-e2e --flag nx-plugin-e2e --fail-on-error"
 }
 
 @test "skips packages with missing coverage directories" {

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -488,3 +488,43 @@ EOF
 
   rm -rf "$home_dir" "$mock_bin_dir"
 }
+
+@test "skips upload when installer bootstrap fails and fail-on-error is false" {
+  home_dir="$(mktemp -d)"
+  mock_bin_dir="$(mktemp -d)"
+
+  cat >"$mock_bin_dir/python3" <<'EOF'
+#! /usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/python3"
+  cat >"$mock_bin_dir/pip3" <<'EOF'
+#! /usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/pip3"
+  cat >"$mock_bin_dir/curl" <<'EOF'
+#! /usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/curl"
+  cat >"$mock_bin_dir/wget" <<'EOF'
+#! /usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/wget"
+
+  HOME="$home_dir" \
+  PATH="$mock_bin_dir:$PATH" \
+  CODECOV_FAIL_ON_ERROR=false \
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_output --partial "WARNING: codecovcli is not available and no Python pip installer could be bootstrapped, but CODECOV_FAIL_ON_ERROR is disabled. Skipping coverage upload."
+
+  rm -rf "$home_dir" "$mock_bin_dir"
+}

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -268,263 +268,122 @@ teardown() {
   assert_equal "$(mock_get_call_num "${codecov_mock}")" 0
 }
 
-@test "bootstraps pip with ensurepip when python3 -m pip is unavailable" {
-  home_dir="$(mktemp -d)"
+@test "downloads Codecov CLI from cli.codecov.io when not on PATH and skip validation" {
   mock_bin_dir="$(mktemp -d)"
-  mkdir -p "$home_dir/.local/bin"
-
-  cat >"$mock_bin_dir/python3" <<'EOF'
-#! /usr/bin/env bash
-if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "--version" ]]; then
-  if [[ -f "$HOME/.ensurepip-ready" ]]; then
-    exit 0
-  fi
-  exit 1
-fi
-
-if [[ "$1" == "-m" && "$2" == "ensurepip" ]]; then
-  mkdir -p "$HOME/.local/bin"
-  touch "$HOME/.ensurepip-ready"
-  exit 0
-fi
-
-if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "install" ]]; then
-  mkdir -p "$HOME/.local/bin"
-  cat >"$HOME/.local/bin/codecovcli" <<'INNER'
-#! /usr/bin/env bash
-printf '%s\n' "$*" >>"$HOME/codecov-invocations.log"
-INNER
-  chmod +x "$HOME/.local/bin/codecovcli"
-  exit 0
-fi
-
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/python3"
-
-  HOME="$home_dir" \
-  PATH="$mock_bin_dir:$PATH" \
-  CODECOV_TOKEN='' \
-  MONOREPO_ROOT="$TEST_DIR" \
-  COVERAGE_DIR="$COVERAGE_DIR" \
-  PNPM_BINARY="${pnpm_mock}" \
-  run uploadMonorepoCoverageWithCodecovCli.sh
-
-  assert_success
-  assert_file_exist "$home_dir/.local/bin/codecovcli"
-  assert_output --partial "Uploading coverage for package nx-plugin"
-
-  rm -rf "$home_dir" "$mock_bin_dir"
-}
-
-@test "bootstraps pip with get-pip.py when ensurepip and pip3 are unavailable" {
-  home_dir="$(mktemp -d)"
-  mock_bin_dir="$(mktemp -d)"
-  mkdir -p "$home_dir/.local/bin"
-
-  cat >"$mock_bin_dir/python3" <<'EOF'
-#! /usr/bin/env bash
-if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "--version" ]]; then
-  if [[ -f "$HOME/.get-pip-ready" ]]; then
-    exit 0
-  fi
-  exit 1
-fi
-
-if [[ "$1" == "-m" && "$2" == "ensurepip" ]]; then
-  exit 1
-fi
-
-if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "install" ]]; then
-  mkdir -p "$HOME/.local/bin"
-  cat >"$HOME/.local/bin/codecovcli" <<'INNER'
-#! /usr/bin/env bash
-printf '%s\n' "$*" >>"$HOME/codecov-invocations.log"
-INNER
-  chmod +x "$HOME/.local/bin/codecovcli"
-  exit 0
-fi
-
-if [[ "$1" == */get-pip.py && "$2" == "--user" ]]; then
-  touch "$HOME/.get-pip-ready"
-  exit 0
-fi
-
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/python3"
+  ln -sfn "$(command -v jq)" "$mock_bin_dir/jq"
 
   cat >"$mock_bin_dir/curl" <<'EOF'
 #! /usr/bin/env bash
-if [[ "$1" == "-fsSL" && "$2" == "https://bootstrap.pypa.io/get-pip.py" && "$3" == "-o" ]]; then
-  mkdir -p "$(dirname "$4")"
-  printf '# bootstrap\n' >"$4"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/curl"
-  cat >"$mock_bin_dir/pip3" <<'EOF'
-#! /usr/bin/env bash
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/pip3"
-
-  HOME="$home_dir" \
-  PATH="$mock_bin_dir:$PATH" \
-  CODECOV_TOKEN='' \
-  MONOREPO_ROOT="$TEST_DIR" \
-  COVERAGE_DIR="$COVERAGE_DIR" \
-  PNPM_BINARY="${pnpm_mock}" \
-  run uploadMonorepoCoverageWithCodecovCli.sh
-
-  assert_success
-  assert_file_exist "$home_dir/.local/bin/codecovcli"
-  assert_output --partial "Uploading coverage for package nx-plugin"
-
-  rm -rf "$home_dir" "$mock_bin_dir"
-}
-
-@test "bootstraps pip with get-pip.py via wget when curl is unavailable" {
-  home_dir="$(mktemp -d)"
-  mock_bin_dir="$(mktemp -d)"
-  mkdir -p "$home_dir/.local/bin"
-
-  cat >"$mock_bin_dir/python3" <<'EOF'
-#! /usr/bin/env bash
-if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "--version" ]]; then
-  if [[ -f "$HOME/.get-pip-ready" ]]; then
-    exit 0
+prev=
+for a in "$@"; do
+  if [[ "$prev" == "-o" ]]; then
+    if [[ "$*" == *"cli.codecov.io"* ]] && [[ "$*" == *"/codecov"* ]]; then
+      {
+        printf '#!/usr/bin/env bash\n'
+        printf 'exit 0\n'
+      } >"$a"
+      chmod +x "$a"
+      exit 0
+    fi
   fi
-  exit 1
-fi
-
-if [[ "$1" == "-m" && "$2" == "ensurepip" ]]; then
-  exit 1
-fi
-
-if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "install" ]]; then
-  mkdir -p "$HOME/.local/bin"
-  cat >"$HOME/.local/bin/codecovcli" <<'INNER'
-#! /usr/bin/env bash
-printf '%s\n' "$*" >>"$HOME/codecov-invocations.log"
-INNER
-  chmod +x "$HOME/.local/bin/codecovcli"
-  exit 0
-fi
-
-if [[ "$1" == */get-pip.py && "$2" == "--user" ]]; then
-  touch "$HOME/.get-pip-ready"
-  exit 0
-fi
-
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/python3"
-
-  cat >"$mock_bin_dir/curl" <<'EOF'
-#! /usr/bin/env bash
+  prev=$a
+done
 exit 1
 EOF
   chmod +x "$mock_bin_dir/curl"
 
-  cat >"$mock_bin_dir/wget" <<'EOF'
-#! /usr/bin/env bash
-if [[ "$1" == "-qO" ]]; then
-  mkdir -p "$(dirname "$2")"
-  printf '# bootstrap\n' >"$2"
-  exit 0
-fi
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/wget"
-
-  cat >"$mock_bin_dir/pip3" <<'EOF'
-#! /usr/bin/env bash
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/pip3"
-
-  HOME="$home_dir" \
-  PATH="$mock_bin_dir:$PATH" \
   CODECOV_TOKEN='' \
+  CODECOV_SKIP_VALIDATION=true \
+  PATH="$mock_bin_dir:$PATH" \
   MONOREPO_ROOT="$TEST_DIR" \
   COVERAGE_DIR="$COVERAGE_DIR" \
   PNPM_BINARY="${pnpm_mock}" \
   run uploadMonorepoCoverageWithCodecovCli.sh
 
   assert_success
-  assert_file_exist "$home_dir/.local/bin/codecovcli"
+  assert_output --partial "Downloading Codecov CLI from"
   assert_output --partial "Uploading coverage for package nx-plugin"
 
-  rm -rf "$home_dir" "$mock_bin_dir"
+  rm -rf "$mock_bin_dir"
 }
 
-@test "fails with actionable error when no pip installation path exists" {
-  home_dir="$(mktemp -d)"
+@test "fails when Codecov CLI download returns non-zero" {
   mock_bin_dir="$(mktemp -d)"
-
-  cat >"$mock_bin_dir/python3" <<'EOF'
+  ln -sfn "$(command -v jq)" "$mock_bin_dir/jq"
+  cat >"$mock_bin_dir/curl" <<'EOF'
 #! /usr/bin/env bash
-exit 1
+if [[ "$*" == *"cli.codecov.io"* && "$*" == *"/codecov" ]]; then
+  if [[ "$*" == *" -o "* ]]; then
+    exit 7
+  fi
+fi
+exit 0
 EOF
-  chmod +x "$mock_bin_dir/python3"
-  cat >"$mock_bin_dir/pip3" <<'EOF'
-#! /usr/bin/env bash
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/pip3"
+  chmod +x "$mock_bin_dir/curl"
 
-  HOME="$home_dir" \
-  PATH="$mock_bin_dir:$PATH" \
   CODECOV_TOKEN='' \
+  CODECOV_SKIP_VALIDATION=true \
+  PATH="$mock_bin_dir:$PATH" \
   MONOREPO_ROOT="$TEST_DIR" \
   COVERAGE_DIR="$COVERAGE_DIR" \
   PNPM_BINARY="${pnpm_mock}" \
   run uploadMonorepoCoverageWithCodecovCli.sh
 
   assert_failure
-  assert_output --partial "ERROR: codecovcli is not available and no Python pip installer could be bootstrapped."
+  assert_output --partial "ERROR: failed to download Codecov CLI"
 
-  rm -rf "$home_dir" "$mock_bin_dir"
+  rm -rf "$mock_bin_dir"
 }
 
-@test "skips upload when installer bootstrap fails and fail-on-error is false" {
-  home_dir="$(mktemp -d)"
-  mock_bin_dir="$(mktemp -d)"
+@test "fails when GPG is missing and CLI validation is enabled" {
+  # PATH: tools first (no gpg) so download succeeds, then GPG check fails. Include repo scripts on PATH
+  # so the upload script is found; only bare utilities are symlinks, not gpg.
+  tools_dir="$(mktemp -d)"
+  for c in bash jq mktemp rm tr grep cut sed; do
+    ln -sfn "$(command -v "$c")" "$tools_dir/$c"
+  done
+  if command -v arch >/dev/null 2>&1; then
+    ln -sfn "$(command -v arch)" "$tools_dir/arch"
+  elif command -v /usr/bin/arch >/dev/null 2>&1; then
+    ln -sfn /usr/bin/arch "$tools_dir/arch"
+  fi
+  for u in /bin/uname /usr/bin/uname; do
+    if [[ -x "$u" ]]; then
+      ln -sfn "$u" "$tools_dir/uname"
+      break
+    fi
+  done
 
-  cat >"$mock_bin_dir/python3" <<'EOF'
+  cat >"$tools_dir/curl" <<'EOF'
 #! /usr/bin/env bash
-exit 1
+prev=
+for a in "$@"; do
+  if [[ "$prev" == "-o" ]]; then
+    if [[ "$*" == *"cli.codecov.io"* && "$*" == *"/codecov"* ]]; then
+      {
+        printf '#!/bin/sh\n'
+        printf 'exit 0\n'
+      } >"$a"
+      chmod +x "$a"
+      exit 0
+    fi
+  fi
+  prev=$a
+done
+exit 0
 EOF
-  chmod +x "$mock_bin_dir/python3"
-  cat >"$mock_bin_dir/pip3" <<'EOF'
-#! /usr/bin/env bash
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/pip3"
-  cat >"$mock_bin_dir/curl" <<'EOF'
-#! /usr/bin/env bash
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/curl"
-  cat >"$mock_bin_dir/wget" <<'EOF'
-#! /usr/bin/env bash
-exit 1
-EOF
-  chmod +x "$mock_bin_dir/wget"
+  chmod +x "$tools_dir/curl"
 
-  HOME="$home_dir" \
-  PATH="$mock_bin_dir:$PATH" \
-  CODECOV_FAIL_ON_ERROR=false \
   CODECOV_TOKEN='' \
+  CODECOV_SKIP_VALIDATION=false \
+  PATH="$tools_dir:$PROJECT_ROOT/src/scripts" \
   MONOREPO_ROOT="$TEST_DIR" \
   COVERAGE_DIR="$COVERAGE_DIR" \
   PNPM_BINARY="${pnpm_mock}" \
   run uploadMonorepoCoverageWithCodecovCli.sh
 
-  assert_success
-  assert_output --partial "WARNING: codecovcli is not available and no Python pip installer could be bootstrapped, but CODECOV_FAIL_ON_ERROR is disabled. Skipping coverage upload."
+  assert_failure
+  assert_output --partial "ERROR: gpg is not installed"
 
-  rm -rf "$home_dir" "$mock_bin_dir"
+  rm -rf "$tools_dir"
 }

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -317,6 +317,74 @@ EOF
   rm -rf "$home_dir" "$mock_bin_dir"
 }
 
+@test "bootstraps pip with get-pip.py when ensurepip and pip3 are unavailable" {
+  home_dir="$(mktemp -d)"
+  mock_bin_dir="$(mktemp -d)"
+  mkdir -p "$home_dir/.local/bin"
+
+  cat >"$mock_bin_dir/python3" <<'EOF'
+#! /usr/bin/env bash
+if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "--version" ]]; then
+  if [[ -f "$HOME/.get-pip-ready" ]]; then
+    exit 0
+  fi
+  exit 1
+fi
+
+if [[ "$1" == "-m" && "$2" == "ensurepip" ]]; then
+  exit 1
+fi
+
+if [[ "$1" == "-m" && "$2" == "pip" && "$3" == "install" ]]; then
+  mkdir -p "$HOME/.local/bin"
+  cat >"$HOME/.local/bin/codecovcli" <<'INNER'
+#! /usr/bin/env bash
+printf '%s\n' "$*" >>"$HOME/codecov-invocations.log"
+INNER
+  chmod +x "$HOME/.local/bin/codecovcli"
+  exit 0
+fi
+
+if [[ "$1" == */get-pip.py && "$2" == "--user" ]]; then
+  touch "$HOME/.get-pip-ready"
+  exit 0
+fi
+
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/python3"
+
+  cat >"$mock_bin_dir/curl" <<'EOF'
+#! /usr/bin/env bash
+if [[ "$1" == "-fsSL" && "$2" == "https://bootstrap.pypa.io/get-pip.py" && "$3" == "-o" ]]; then
+  mkdir -p "$(dirname "$4")"
+  touch "$4"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/curl"
+  cat >"$mock_bin_dir/pip3" <<'EOF'
+#! /usr/bin/env bash
+exit 1
+EOF
+  chmod +x "$mock_bin_dir/pip3"
+
+  HOME="$home_dir" \
+  PATH="$mock_bin_dir:$PATH" \
+  CODECOV_TOKEN='' \
+  MONOREPO_ROOT="$TEST_DIR" \
+  COVERAGE_DIR="$COVERAGE_DIR" \
+  PNPM_BINARY="${pnpm_mock}" \
+  run uploadMonorepoCoverageWithCodecovCli.sh
+
+  assert_success
+  assert_file_exist "$home_dir/.local/bin/codecovcli"
+  assert_output --partial "Uploading coverage for package nx-plugin"
+
+  rm -rf "$home_dir" "$mock_bin_dir"
+}
+
 @test "fails with actionable error when no pip installation path exists" {
   home_dir="$(mktemp -d)"
   mock_bin_dir="$(mktemp -d)"
@@ -341,7 +409,7 @@ EOF
   run uploadMonorepoCoverageWithCodecovCli.sh
 
   assert_failure
-  assert_output --partial "ERROR: codecovcli is not available and no Python pip installer was found."
+  assert_output --partial "ERROR: codecovcli is not available and no Python pip installer could be bootstrapped."
 
   rm -rf "$home_dir" "$mock_bin_dir"
 }


### PR DESCRIPTION
## Summary
- Install the Codecov CLI like the official `codecov/codecov` orb: download `codecov` from `https://cli.codecov.io`, verify with GPG + SHA256 (optional skip via `CODECOV_SKIP_VALIDATION` / orb parameter `skip-codecov-cli-validation`).
- Remove pip-based install paths that broke on images with Python but no pip.
- **Bugfixes:** silence `shasum`/`sha256sum -c` stdout during validation so it cannot corrupt Bash command substitution (the `codecov: OK` / missing file errors). Pass `codecov -v` globally because `upload-coverage` on the cli.codecov.io binary rejects `--verbose`.
## Orb command
`upload-monorepo-coverage` gains `codecov-version`, `skip-codecov-cli-validation`, `codecov-cli-base-url`; `fail-on-error` default is `true`.
## Changeset
`.changeset/fair-lions-learn.md` (patch).
## Verification
- Bats: `test/uploadMonorepoCoverageWithCodecovCli.bats`
- Downstream `lint` confirmed with dev orb `45c8fc2ae07b06854798f7ce3713995a5dcadec8`.