### PR TITLE
fix(ci): skip git hooks for changesets release PR commits

### DIFF
--- a/.changeset/release-pr-skip-hooks.md
+++ b/.changeset/release-pr-skip-hooks.md
@@ -1,0 +1,7 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Skip git hooks for Changesets release PR commits so CI can commit without system tools like yamllint.
+
+Release automation runs `git commit` on a minimal Node image; Husky pre-commit previously invoked `pnpm lint`, which failed when `yamllint` was not installed.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+# CI shells (e.g. CircleCI) usually lack hook-only deps such as system yamllint; lint runs there as explicit workflow steps.
+[ -n "${CI:-}" ] && exit 0
+
 pnpm lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,9 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 # CircleCI release jobs may not have hook-only deps (for example system yamllint);
-# skip only in CircleCI so local shells with CI=false do not bypass hooks.
-[ -n "${CIRCLECI:-}" ] && exit 0
+# skip only when CIRCLECI is explicitly truthy so local CIRCLECI=false does not bypass hooks.
+if [ "${CIRCLECI:-}" = "true" ] || [ "${CIRCLECI:-}" = "1" ]; then
+  exit 0
+fi
 
 pnpm lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,8 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-# CI shells (e.g. CircleCI) usually lack hook-only deps such as system yamllint; lint runs there as explicit workflow steps.
-[ -n "${CI:-}" ] && exit 0
+# CircleCI release jobs may not have hook-only deps (for example system yamllint);
+# skip only in CircleCI so local shells with CI=false do not bypass hooks.
+[ -n "${CIRCLECI:-}" ] && exit 0
 
 pnpm lint

--- a/src/scripts/runChangesetsReleasePr.sh
+++ b/src/scripts/runChangesetsReleasePr.sh
@@ -153,8 +153,8 @@ run_changesets_release_pr_main() {
 
   git checkout -B "$release_branch"
   git add -A
-  # Commit subject must match PR title (single-line).
-  git commit -m "$title"
+  # Commit subject must match PR title (single-line). Skip hooks: automated commits must not require dev-only tools (e.g. yamllint on PATH).
+  git commit --no-verify -m "$title"
 
   repo_slug=${GITHUB_REPO_SLUG:-}
   if [[ -z "$repo_slug" ]]; then


### PR DESCRIPTION
## Summary

Release PR automation failed when `git commit` invoked Husky pre-commit, which runs `pnpm lint` and requires system `yamllint` (missing on CircleCI Node executors).

## Changes

- `runChangesetsReleasePr.sh`: `git commit --no-verify` for the automated versioning commit.
- `.husky/pre-commit`: no-op when `CI` is set (belt-and-suspenders for commits in CI).
- Changeset entry for orb patch release.

Made with [Cursor](https://cursor.com)