### PR TITLE
feat(orb): GitHub release train after changesets gated publish

### DIFF
--- a/.changeset/github-release-train-target-ref.md
+++ b/.changeset/github-release-train-target-ref.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-`runGithubReleaseTrain` only uses `CIRCLE_SHA1` as the release target when that commit exists in the current repository, so Bats fixtures (and other secondary clones) on CircleCI fall back to `HEAD` instead of inheriting the pipeline checkout SHA.

--- a/.changeset/github-release-train-target-ref.md
+++ b/.changeset/github-release-train-target-ref.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+`runGithubReleaseTrain` only uses `CIRCLE_SHA1` as the release target when that commit exists in the current repository, so Bats fixtures (and other secondary clones) on CircleCI fall back to `HEAD` instead of inheriting the pipeline checkout SHA.

--- a/.changeset/github-release-train.md
+++ b/.changeset/github-release-train.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": minor
+---
+
+`changesets-gated-publish` now defaults to creating a GitHub Release after publish: UTC train id `YYYY.MM.DD.N` as the release title, git tag `release/YYYY.MM.DD.N` by default, and notes from merged `CHANGELOG.md` diffs. Repos can set `create-github-release: false` to opt out.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Repository-specific guidance in the local override section of `AGENTS.md` takes 
 - When a repository uses **Atlassian Changesets** (a `.changeset/` config and `@changesets/cli` in the workspace), **do not** hand-edit the root or package `version` fields in `package.json` to release user-facing changes, and **do not** hand-edit `CHANGELOG.md` to add release notes for those changes. Release automation applies those updates when maintainers run `changeset version` (or the organization’s release pipeline does).
 - Use **`pnpm changeset` / `changeset add`**, or add a new tracked markdown file under **`.changeset/`** with the correct `patch` / `minor` / `major` frontmatter, so the intended semver bump and changelog line are generated at release time.
 - Follow `org/agents/skills/changesets-hygiene/SKILL.md` when introducing or changing releaseable work.
+- **Exceptions — no Changeset:** Do **not** add a `.changeset/` entry for **documentation-only** work that does not alter shipped package behavior, including **new or updated ADRs** (`**/docs/adr/**/*.md`, `org/docs/adr/**/*.md`) and **agent or contributor guidance** (for example `AGENTS.md`, `org/agents/AGENTS.org.md`, `REVIEW-CHECKLIST.md`, `org/agents/skills/**/*.md`, `.agents/skills/**`, Cursor rules/skills mirroring those). Ship those edits without a semver bump driven by Changesets unless the repository owner explicitly asks to version a doc-only policy as a patch.
 
 ## Org subtree safety
 

--- a/README.md
+++ b/README.md
@@ -64,19 +64,11 @@ After:
 We welcome [issues](https://github.com/chiubaka/circleci-orb/issues) to and [pull requests](https://github.com/chiubaka/circleci-orb/pulls) against this repository!
 
 ### How to Publish An Update
-1. Merge pull requests with desired changes to the main branch.
-    - For the best experience, squash-and-merge and use [Conventional Commit Messages](https://conventionalcommits.org/).
-2. Find the current version of the orb.
-    - You can run `circleci orb info chiubaka/circleci-orb | grep "Latest"` to see the current version.
-3. Create a [new Release](https://github.com/chiubaka/circleci-orb/releases/new) on GitHub.
-    - Click "Choose a tag" and _create_ a new [semantically versioned](http://semver.org/) tag. (ex: v1.0.0)
-      - We will have an opportunity to change this before we publish if needed after the next step.
-4.  Click _"+ Auto-generate release notes"_.
-    - This will create a summary of all of the merged pull requests since the previous release.
-    - If you have used _[Conventional Commit Messages](https://conventionalcommits.org/)_ it will be easy to determine what types of changes were made, allowing you to ensure the correct version tag is being published.
-5. Now ensure the version tag selected is semantically accurate based on the changes included.
-6. Click _"Publish Release"_.
-    - This will push a new tag and trigger your publishing pipeline on CircleCI.
+
+1. Land changes on `master` (squash-and-merge is recommended; use [Conventional Commits](https://conventionalcommits.org/) where helpful).
+2. When [Changesets](https://github.com/changesets/changesets) has pending entries, CI opens a release PR (`changesets-release-pr`). **Squash-merge** that PR using the default title prefix `chore(release): version packages` so `changesets-gated-publish` can assert the merge.
+3. The gated publish job runs `changeset publish` (or this repo’s `release:orb` script), pushes the orb semver tag `vX.Y.Z` for registry consumers, then **by default** creates a **GitHub Release** whose title is the UTC train id `YYYY.MM.DD.N`, a matching git tag `release/YYYY.MM.DD.N`, and release notes built from the merged `CHANGELOG.md` diff. Set `create-github-release: false` on `chiubaka/changesets-gated-publish` if a repo opts out.
+4. Production orb registry releases still follow the `orb-tools/publish` workflow on semver tags `vX.Y.Z` (see [CircleCI orb registry](https://circleci.com/orbs/registry/orb/chiubaka/circleci-orb)); train tags do not replace that contract.
 
 ## Development
 

--- a/docs/adr/0001-chiubaka-circleci-orb-design-defaults-and-escape-hatches.md
+++ b/docs/adr/0001-chiubaka-circleci-orb-design-defaults-and-escape-hatches.md
@@ -51,6 +51,7 @@ Chosen option: **Layered defaults with explicit parameters, shared scripts in th
 - Good, because bash changes are tested in one place.
 - Bad, because the orb maintainers own more surface area (parameters, scripts) and must semver carefully.
 - Bad, because some clients will still need custom jobs; documentation must show **when** to compose commands manually.
+- Neutral: `changesets-gated-publish` with default `create-github-release` adds a **GitHub Release** and a **train git tag** `release/<UTC-date>.N` (title `YYYY.MM.DD.N` only) alongside any existing **semver artifact tags** (for example this repo’s `vX.Y.Z` for `orb-tools/publish`). Workflow filters can keep matching only `^v[0-9]+\.[0-9]+\.[0-9]+$` so train tags do not double-trigger orb production publish; repos that must not create GitHub Releases set `create-github-release: false`.
 
 ### Confirmation
 

--- a/org/agents/AGENTS.org.md
+++ b/org/agents/AGENTS.org.md
@@ -41,6 +41,7 @@ Repository-specific guidance in the local override section of `AGENTS.md` takes 
 - When a repository uses **Atlassian Changesets** (a `.changeset/` config and `@changesets/cli` in the workspace), **do not** hand-edit the root or package `version` fields in `package.json` to release user-facing changes, and **do not** hand-edit `CHANGELOG.md` to add release notes for those changes. Release automation applies those updates when maintainers run `changeset version` (or the organization’s release pipeline does).
 - Use **`pnpm changeset` / `changeset add`**, or add a new tracked markdown file under **`.changeset/`** with the correct `patch` / `minor` / `major` frontmatter, so the intended semver bump and changelog line are generated at release time.
 - Follow `org/agents/skills/changesets-hygiene/SKILL.md` when introducing or changing releaseable work.
+- **Exceptions — no Changeset:** Do **not** add a `.changeset/` entry for **documentation-only** work that does not alter shipped package behavior, including **new or updated ADRs** (`**/docs/adr/**/*.md`, `org/docs/adr/**/*.md`) and **agent or contributor guidance** (for example `AGENTS.md`, `org/agents/AGENTS.org.md`, `REVIEW-CHECKLIST.md`, `org/agents/skills/**/*.md`, `.agents/skills/**`, Cursor rules/skills mirroring those). Ship those edits without a semver bump driven by Changesets unless the repository owner explicitly asks to version a doc-only policy as a patch.
 
 ## Org subtree safety
 

--- a/org/agents/skills/changeset/SKILL.md
+++ b/org/agents/skills/changeset/SKILL.md
@@ -13,6 +13,10 @@ description: >-
 
 A changeset file declares **which packages** bump and **how the change reads in the changelog**. It is the source of truth for release notes in this org’s Changesets workflow (see [ADR 0024](../../../docs/adr/0024-use-changesets-for-library-monorepos.md) and related ADRs).
 
+## When not to author a changeset
+
+For **ADR-only** or **agent-guidance-only** PRs (no changes to shipped packages, orb/scripts, or consumer-facing artifact behavior), **do not** add a `.changeset` file. Use `org/agents/skills/changesets-hygiene/SKILL.md` for the full exception list.
+
 ## Where files live
 
 - Add markdown files under **`.changeset/`** at the repo root (or the configured changeset directory).

--- a/org/agents/skills/changesets-hygiene/SKILL.md
+++ b/org/agents/skills/changesets-hygiene/SKILL.md
@@ -3,7 +3,8 @@ name: changesets-hygiene
 description: >-
   Prevents hand-edited semver and changelog in Changesets-driven repos. Use
   .changeset entries and changeset add/version flows instead; never bump
-  package.json version or CHANGELOG.md to ship features in those repos.
+  package.json version or CHANGELOG.md to ship features in those repos. Skips
+  ADRs and agent-guidance-only edits (see When not to add a Changeset).
 ---
 
 # Changesets hygiene (agents)
@@ -18,6 +19,15 @@ Use in any repository with:
 
 - `.changeset/config.json` (or equivalent) and
 - `@changesets/cli` (or a documented `pnpm changeset` / `changeset` workflow) for release notes.
+
+## When not to add a Changeset
+
+**Do not** create `.changeset/*` entries when the PR only affects:
+
+- **ADRs** or other durable decision docs under `**/docs/adr/**` or `org/docs/adr/**`
+- **Agent/contributor guidance** that does not change runtime or published APIs (for example `AGENTS.md`, `org/agents/AGENTS.org.md`, `REVIEW-CHECKLIST.md`, `org/agents/skills/**`, repo-local `.agents/skills/**`, or tooling-only docs that mirror those)
+
+Those changes are recorded in git and in the docs themselves; they are **not** consumer-facing package releases. If a task mixes guidance-only edits with **releasable** code or config for a published package, add a changeset **only** for the releasable portion.
 
 ## Required behavior
 

--- a/org/agents/skills/review/SKILL.md
+++ b/org/agents/skills/review/SKILL.md
@@ -47,7 +47,7 @@ Run by default after any non-trivial code change and **before** you tell the use
 - [ ] If repeated issues surface, update `AGENTS.md`/`org/agents/AGENTS.org.md` or create/update a focused skill.
 - [ ] Keep skill scope narrow; avoid restating broad org conventions when cross-referencing is sufficient.
 - [ ] Run guidance sync scripts after org-level guidance or skill changes.
-- [ ] On repositories with Changesets, confirm release notes and semver bumps are expressed via a **new or updated** `.changeset/*.md` entry, **not** by editing `package.json` `version` or `CHANGELOG.md` directly, unless a maintainer asked for a hotfix to automation itself (see `org/agents/skills/changesets-hygiene/SKILL.md`).
+- [ ] On repositories with Changesets, when the PR includes **releasable** work (behavior, APIs, orb/scripts, publishable configs), confirm release notes and semver bumps are expressed via a **new or updated** `.changeset/*.md` entry, **not** by editing `package.json` `version` or `CHANGELOG.md` directly, unless a maintainer asked for a hotfix to automation itself (see `org/agents/skills/changesets-hygiene/SKILL.md`). **Skip** this check when the change is **ADRs or agent guidance only** (no changeset expected per that skill).
 
 ## Style and naming
 

--- a/org/agents/skills/update-agent-guidance/SKILL.md
+++ b/org/agents/skills/update-agent-guidance/SKILL.md
@@ -44,7 +44,8 @@ If uncertain, choose repo-level first, then promote to org-level only when porta
 
 ## Critical rules
 
-- On repositories that use **Changesets**, do **not** add release version bumps to `package.json` or new sections to `CHANGELOG.md` in the same change that ships user-facing work; add or update a **`.changeset/*`** file instead, per `org/agents/skills/changesets-hygiene/SKILL.md`, then run the normal release or `changeset version` flow. Hand-editing only belongs to fixing Changesets or changelog tooling in isolation.
+- **Guidance and ADRs without a Changeset:** Edits that are **only** to agent guidance, org skills, or ADRs do **not** require a `.changeset/*` file. Do not add one by default—see `org/agents/skills/changesets-hygiene/SKILL.md` (**When not to add a Changeset**).
+- On repositories that use **Changesets**, when shipping **releasable** work (not guidance-only), do **not** add release version bumps to `package.json` or new sections to `CHANGELOG.md` in the same PR; add or update a **`.changeset/*`** file instead, per `org/agents/skills/changesets-hygiene/SKILL.md`, then run the normal release or `changeset version` flow. Hand-editing only belongs to fixing Changesets or changelog tooling in isolation.
 - Org-level guidance must not depend on repo-specific files or conventions as normative requirements.
 - Keep root `AGENTS.md` bootstrap-compatible:
   - preserve `<!-- ORG_GUIDANCE_START --> ... <!-- ORG_GUIDANCE_END -->`

--- a/org/docs/adr/0030-coordinated-release-model-release-manifests-and-promotion-tags.md
+++ b/org/docs/adr/0030-coordinated-release-model-release-manifests-and-promotion-tags.md
@@ -185,6 +185,7 @@ This approach is expected to evolve naturally into more advanced orchestration s
 
 ## Related ADRs
 
+- [ADR 0037](0037-release-train-identifiers-and-github-releases.md) — canonical `YYYY.MM.DD.N` train identifier and GitHub Releases alignment
 - [ADR 0020](0020-run-production-database-migrations-as-a-separate-deployment-step.md) — migrations as a distinct production step; order relative to artifact phases
 - [ADR 0023](0023-lockstep-versioning-for-related-package-groups.md) — lockstep groups for related packages in library monorepos
 - [ADR 0026](0026-use-changesets-for-application-releases.md) — application versioning and release intent

--- a/org/docs/adr/0031-separation-of-artifact-tags-and-environment-promotion-tags.md
+++ b/org/docs/adr/0031-separation-of-artifact-tags-and-environment-promotion-tags.md
@@ -154,6 +154,7 @@ Application versioning and changelog intent remain driven by Changesets where ap
 
 ## Related ADRs
 
+- [ADR 0037](0037-release-train-identifiers-and-github-releases.md) — canonical release train identifier and GitHub Releases alignment
 - [ADR 0026](0026-use-changesets-for-application-releases.md) — application versioning and user-facing release intent
 - [ADR 0028](0028-version-only-deployable-artifacts-by-default.md) — which artifacts are versioned
 - [ADR 0030](0030-coordinated-release-model-release-manifests-and-promotion-tags.md) — release manifest format, deploy phases, and coordination rules

--- a/org/docs/adr/0037-release-train-identifiers-and-github-releases.md
+++ b/org/docs/adr/0037-release-train-identifiers-and-github-releases.md
@@ -1,0 +1,94 @@
+---
+status: accepted
+date: 2026-05-08
+decision-makers: Daniel Chiu
+---
+
+# Release train identifiers (`YYYY.MM.DD.N`) and GitHub Releases
+
+## Context and Problem Statement
+
+Monorepos that ship multiple versioned artifacts need a **release train** identifier: a single label for “this coordinated cut” that orchestration, manifests, CI, and humans can refer to without ambiguity.
+
+Reasonable options include:
+
+- A **calendar-style identifier** (`YYYY.MM.DD.N`), aligned with phased promotion and release manifests.
+- An **umbrella semver** at the repository root, optionally maintained alongside independent package versions.
+
+Separately, teams often publish **GitHub Releases** as the social and archival surface for a batch publish. That raises another question: should the GitHub Release tag follow the **train** identifier, **package** semver, or something else—and how do notes relate to Changesets?
+
+This ADR records which **train identifier** we standardize on and how **GitHub Releases** relate to Changesets and existing orchestration ADRs.
+
+## Decision Drivers
+
+- **Orchestration-first clarity:** coordinated deploys, manifests, and promotion workflows need a stable, monotonic train identity that works across artifacts.
+- **Operational pragmatism:** prefer conventions that compose with existing manifest and tag models without extra bespoke versioning machinery at the repository root.
+- **Honest semantics:** train identifiers should not imply a second, competing semver contract for consumers who pin individual packages.
+- **Compatibility:** align with Changesets as the system of record for **package-level** semver and changelogs ([ADR 0024](0024-use-changesets-for-library-monorepos.md), [ADR 0026](0026-use-changesets-for-application-releases.md)).
+- **Auditability:** release history should tie together “what shipped together” without multiplying incompatible numbering schemes.
+
+## Considered Options
+
+- Calendar-based release train identifier (`YYYY.MM.DD.N`)
+- Umbrella semver at the repository root (managed manually or derived from batch bump severity)
+- GitHub Releases tagged only with individual package versions (one release per package)
+
+## Decision Outcome
+
+Chosen option: **Standardize on `YYYY.MM.DD.N` as the canonical release train identifier** for coordinated releases and related automation. **GitHub Releases**, when published for a monorepo batch, **SHOULD** use this same train identifier as the **GitHub release tag and title prefix** (for example `2026.04.06.1` or `v2026.04.06.1` if a `v` prefix is required by tooling—either form is acceptable if used consistently within a repository).
+
+**Release notes** for that GitHub Release **SHOULD** be assembled from the **Changesets-generated changelogs** and summaries for packages and deployable artifacts included in that publish batch ([ADR 0024](0024-use-changesets-for-library-monorepos.md), [ADR 0026](0026-use-changesets-for-application-releases.md), [ADR 0027](0027-use-single-changesets-workflow-in-hybrid-monorepos.md)). The train identifier names the **batch**; per-package semver remains the compatibility surface for consumers.
+
+**Justification:** Calendar train identifiers match the orchestration model already defined for release manifests and promotion tags ([ADR 0030](0030-coordinated-release-model-release-manifests-and-promotion-tags.md), [ADR 0031](0031-separation-of-artifact-tags-and-environment-promotion-tags.md)), avoid inventing a parallel umbrella semver that does not map cleanly to independent package versions, and keep GitHub Releases aligned with “one batch / one train” without requiring one GitHub Release per published package.
+
+### Consequences
+
+- Good, because **one canonical train id** can span manifests, promotion flow, and GitHub Release tagging.
+- Good, because **no extra root-level semver policy** is required solely for naming releases.
+- Good, because **compatibility intent** stays on **package versions** and Changesets, reducing ambiguity for library consumers.
+- Good, because **monotonic, sortable** train ids support operational ordering and multiple cuts per calendar day via `N`.
+- Bad, because the train id **does not encode** semver bump magnitude for the batch (unlike an umbrella semver chosen to reflect “major vs minor”); teams rely on **per-package changelogs** and summaries for that signal.
+- Bad, because repositories that **do not** use coordinated manifests still need local discipline to assign the next valid `N` for a given date when creating a train id (same discipline as [ADR 0031](0031-separation-of-artifact-tags-and-environment-promotion-tags.md)).
+
+### Confirmation
+
+- Repositories that publish GitHub Releases for batched monorepo publishes use a **train-aligned** tag consistent with this ADR.
+- Release manifest `release` fields and promotion-tag logical ids remain consistent with [ADR 0030](0030-coordinated-release-model-release-manifests-and-promotion-tags.md) and [ADR 0031](0031-separation-of-artifact-tags-and-environment-promotion-tags.md).
+- Package semver and changelogs continue to come from **Changesets**, not from the train identifier alone.
+
+## Pros and Cons of the Options
+
+### Calendar-based train identifier (`YYYY.MM.DD.N`)
+
+Train identity matches manifest `release` values and promotion-tag stems; increment rules for `N` are defined in [ADR 0031](0031-separation-of-artifact-tags-and-environment-promotion-tags.md).
+
+- Good, because it **aligns orchestration, auditing, and GitHub tagging** when teams adopt GitHub Releases.
+- Good, because it **avoids misleading** “repo-level semver” when packages version independently.
+- Good, because it **reuses** an established pattern already specified for coordinated releases.
+- Neutral, because “when” is visible in the id; **supplementary** context still comes from GitHub metadata and changelogs.
+- Bad, because it does not communicate **aggregate semver intent** for the whole batch.
+
+### Umbrella semver at the repository root
+
+- Good, because a **single semver** can summarize “how large” a batch feels for marketing or platform narratives.
+- Bad, because it is **easy to misread** as a consumer compatibility Version when packages keep **independent** semvers ([ADR 0023](0023-lockstep-versioning-for-related-package-groups.md)).
+- Bad, because **automatic** alignment with independent packages requires **extra tooling or policy** beyond Changesets defaults.
+
+### GitHub Releases per package version
+
+- Good, because each tag matches **one npm version**.
+- Bad, because **batched** monorepo publishes become **noisy** on GitHub and duplicate Changesets’ batch story.
+
+## More Information
+
+**Relationship to package semver:** Train identifiers name **release trains** for coordination and publishing ceremonies. **Packages and deployable artifacts** keep their normal **semver** and changelog story under Changesets. Artifact tags for immutable builds remain separate from promotion tags as described in [ADR 0031](0031-separation-of-artifact-tags-and-environment-promotion-tags.md).
+
+**Repositories without coordinated manifests:** Some monorepos may still publish a **GitHub Release** per batch without adopting `.releases/` manifests. They **should still** use `YYYY.MM.DD.N` for train-aligned tags when they want a single umbrella label, and **should** follow the same `N` increment convention per date for consistency.
+
+## Related ADRs
+
+- [ADR 0024](0024-use-changesets-for-library-monorepos.md) — Changesets for libraries; batched release intent
+- [ADR 0026](0026-use-changesets-for-application-releases.md) — Changesets for applications
+- [ADR 0027](0027-use-single-changesets-workflow-in-hybrid-monorepos.md) — single Changesets workflow per repository
+- [ADR 0030](0030-coordinated-release-model-release-manifests-and-promotion-tags.md) — release manifests; logical `release` field
+- [ADR 0031](0031-separation-of-artifact-tags-and-environment-promotion-tags.md) — promotion tags; logical release identifier and `N` rules

--- a/org/docs/adr/README.md
+++ b/org/docs/adr/README.md
@@ -48,6 +48,7 @@ Keep each decision at the narrowest level that still reflects who should follow 
 - `0034-use-github-packages-with-single-chiubaka-scope-for-private-package-distribution.md`
 - `0035-trial-adoption-of-conventional-commits.md`
 - `0036-standardize-package-naming-under-chiubaka-scope-with-ecosystem-prefixes.md`
+- `0037-release-train-identifiers-and-github-releases.md`
 
 If your repository has a contributor or agent guide, link it to this ADR set for concise day-to-day pointers.
 

--- a/src/commands/github-release-train.yml
+++ b/src/commands/github-release-train.yml
@@ -1,0 +1,77 @@
+description: >
+  After a Changesets publish merge, create one GitHub Release per publish batch (ADR 0037).
+  Computes logical train id YYYY.MM.DD.N from current UTC date and existing remote tags, creates
+  git tag <train-tag-prefix><logical-id> (default release/2026.05.12.1), and runs gh release create
+  with title equal to the logical id (default {{logical_train_id}}). Release notes default to
+  excerpts from CHANGELOG.md files changed between HEAD~1 and HEAD (merge-commit mode); empty
+  changelog diff fails the step. Requires origin to point at github.com, GITHUB_TOKEN with
+  contents:write for tag + release, and gh on PATH (use install-github-cli before this command).
+
+parameters:
+  app-dir:
+    type: string
+    default: "."
+    description: Working directory (repository root containing .git).
+  train-tag-prefix:
+    type: string
+    default: "release/"
+    description: >
+      Prefix for the git tag; full tag is prefix plus logical train id YYYY.MM.DD.N (UTC).
+      Use empty string for bare logical-id tags.
+  draft:
+    type: boolean
+    default: false
+    description: Pass --draft to gh release create.
+  prerelease:
+    type: boolean
+    default: false
+    description: Pass --prerelease to gh release create.
+  title-template:
+    type: string
+    default: "{{logical_train_id}}"
+    description: >
+      GitHub release title; default replaces {{logical_train_id}} with YYYY.MM.DD.N (UTC).
+      Overriding can break parity with release manifests (ADR 0030).
+  target-ref:
+    type: string
+    default: "<< pipeline.git.revision >>"
+    description: >
+      Commit or ref passed to gh --target (defaults to the pipeline revision). Empty falls back to
+      CIRCLE_SHA1 or HEAD in the script.
+  on-existing-tag:
+    type: enum
+    enum:
+      - skip
+      - fail
+    default: skip
+    description: >
+      When the computed tag already exists on origin at the same target commit, skip exits 0;
+      fail exits non-zero. A tag pointing at a different commit always fails.
+  notes-extra-file:
+    type: string
+    default: ""
+    description: Optional file whose contents are prepended before merge-commit notes (or used alone in body-file mode when configured).
+  release-notes-source:
+    type: enum
+    enum:
+      - merge-commit
+      - body-file
+    default: merge-commit
+    description: >
+      merge-commit builds notes from HEAD~1..HEAD CHANGELOG.md paths (non-empty list required).
+      body-file uses notes-extra-file as the entire body (file must exist).
+
+steps:
+  - run:
+      name: GitHub release train (ADR 0037)
+      working_directory: << parameters.app-dir >>
+      command: << include(scripts/runGithubReleaseTrain.sh) >>
+      environment:
+        TRAIN_TAG_PREFIX: << parameters.train-tag-prefix >>
+        DRAFT: << parameters.draft >>
+        PRERELEASE: << parameters.prerelease >>
+        TITLE_TEMPLATE: << parameters.title-template >>
+        TARGET_REF: << parameters.target-ref >>
+        ON_EXISTING_TAG: << parameters.on-existing-tag >>
+        NOTES_EXTRA_FILE: << parameters.notes-extra-file >>
+        RELEASE_NOTES_SOURCE: << parameters.release-notes-source >>

--- a/src/examples/changesets-gated-publish-path-filtering.yml
+++ b/src/examples/changesets-gated-publish-path-filtering.yml
@@ -54,5 +54,7 @@ usage:
   #           - equal: [true, << pipeline.parameters.run-changesets-publish >>]
   #       jobs:
   #         - chiubaka/changesets-gated-publish:
-  #             context: [github-packages-publish]
+  #             context: [github-packages-publish, github-release-pr-bot]
   #             primary-branch: master
+  #             # create-github-release defaults to true: git tag release/<UTC>.N + GitHub Release titled <UTC>.N
+  #             # create-github-release: false

--- a/src/examples/changesets-release-pr.yml
+++ b/src/examples/changesets-release-pr.yml
@@ -2,7 +2,9 @@ description: >
   On each push to the default branch, run changesets-release-pr to open or refresh a PR from
   release/<default-branch> when there are pending .changeset/*.md files. Provide GITHUB_TOKEN via a
   context (repo contents, pull requests, workflow; push access to release/* branches). Use squash merge
-  on that PR so the gated publish job can match the commit subject prefix.
+  on that PR so the gated publish job can match the commit subject prefix; after merge,
+  changesets-gated-publish (default create-github-release: true) publishes packages and opens a GitHub
+  Release with notes from merged CHANGELOG excerpts (ADR 0037).
 
 usage:
   version: 2.1

--- a/src/jobs/changesets-gated-publish.yml
+++ b/src/jobs/changesets-gated-publish.yml
@@ -1,7 +1,8 @@
 description: >
   After a squash-merged release PR, run assert-release-merge then the same publish path as
-  job publish (registry auth, optional build, pnpm exec changeset publish). Pair with a path-filtering
-  + continuation workflow on the client so this job only runs for relevant merges.
+  job publish (registry auth, optional build, pnpm exec changeset publish). By default, when
+  create-github-release is true, also creates a GitHub Release and UTC train git tag (ADR 0037).
+  Pair with a path-filtering + continuation workflow on the client so this job only runs for relevant merges.
 
 executor:
   name: docker-node
@@ -122,6 +123,35 @@ parameters:
     type: boolean
     default: false
     description: When true, assert HEAD deletes at least one path under .changeset/.
+  create-github-release:
+    type: boolean
+    default: true
+    description: >
+      When true, after publish runs install-github-cli and github-release-train (GitHub Release + train
+      tag). Requires GITHUB_TOKEN with contents:write. Set false for repos that opt out of GitHub Releases.
+  train-tag-prefix:
+    type: string
+    default: "release/"
+    description: Passed to github-release-train (git tag prefix before UTC logical id YYYY.MM.DD.N).
+  release-train-draft:
+    type: boolean
+    default: false
+    description: Passed to github-release-train (--draft).
+  release-train-prerelease:
+    type: boolean
+    default: false
+    description: Passed to github-release-train (--prerelease).
+  release-train-title-template:
+    type: string
+    default: "{{logical_train_id}}"
+    description: Passed to github-release-train (GitHub release title template).
+  release-train-on-existing-tag:
+    type: enum
+    enum:
+      - skip
+      - fail
+    default: skip
+    description: Passed to github-release-train idempotency behavior when the train tag already exists.
 
 steps:
   - setup:
@@ -164,4 +194,15 @@ steps:
       app-dir: << parameters.app-dir >>
       dry-run: << parameters.dry-run >>
       publish-script: << parameters.publish-script >>
+  - when:
+      condition: << parameters.create-github-release >>
+      steps:
+        - install-github-cli
+        - github-release-train:
+            app-dir: << parameters.app-dir >>
+            train-tag-prefix: << parameters.train-tag-prefix >>
+            draft: << parameters.release-train-draft >>
+            prerelease: << parameters.release-train-prerelease >>
+            title-template: << parameters.release-train-title-template >>
+            on-existing-tag: << parameters.release-train-on-existing-tag >>
   - steps: << parameters.cleanup-steps >>

--- a/src/scripts/runChangesetsReleasePr.sh
+++ b/src/scripts/runChangesetsReleasePr.sh
@@ -1,5 +1,7 @@
 #! /usr/bin/env bash
 # Pending changesets -> changeset version -> commit on release/<primary> -> gh PR. Requires GITHUB_TOKEN, gh, git push.
+# After squash-merge, gated publish uses runGithubReleaseTrain.sh to build GitHub Release notes from
+# the same style of per-package CHANGELOG excerpts (merge diff HEAD~1..HEAD).
 set -euo pipefail
 
 count_pending_changesets() {

--- a/src/scripts/runGithubReleaseTrain.sh
+++ b/src/scripts/runGithubReleaseTrain.sh
@@ -215,8 +215,12 @@ run_github_release_train_main() {
   prefix=${TRAIN_TAG_PREFIX:-release/}
 
   target_ref=${TARGET_REF:-}
-  if [[ -z "$target_ref" ]]; then
-    target_ref=${CIRCLE_SHA1:-}
+  # CircleCI sets CIRCLE_SHA1 for the job checkout. Bats fixtures use a separate git clone; inheriting
+  # CIRCLE_SHA1 would point at a commit that does not exist in the fixture repo and break tag/HEAD logic.
+  if [[ -z "$target_ref" ]] && [[ -n "${CIRCLE_SHA1:-}" ]]; then
+    if git rev-parse --verify "${CIRCLE_SHA1}^{commit}" >/dev/null 2>&1; then
+      target_ref=${CIRCLE_SHA1}
+    fi
   fi
   if [[ -z "$target_ref" ]]; then
     target_ref=HEAD

--- a/src/scripts/runGithubReleaseTrain.sh
+++ b/src/scripts/runGithubReleaseTrain.sh
@@ -1,0 +1,330 @@
+#! /usr/bin/env bash
+# GitHub Release train (ADR 0037): UTC calendar train id YYYY.MM.DD.N, git tag prefix + id, title = logical id.
+# Release notes for default merge-commit mode come from HEAD~1..HEAD CHANGELOG.md diffs (same excerpt
+# shape as runChangesetsReleasePr.sh build_pr_body_file — helpers duplicated intentionally; see that file).
+# Optional test-only: UTC_DATE_OVERRIDE=YYYY.MM.DD fixes the calendar portion; GITHUB_RELEASE_TRAIN_KEEP_NOTES_FILE=true skips deleting the temp notes file after exit (Bats).
+set -euo pipefail
+
+pkg_at_version() {
+  node -e '
+    const fs = require("fs");
+    const p = process.argv[1];
+    const j = JSON.parse(fs.readFileSync(p, "utf8"));
+    if (j.name && j.version) process.stdout.write(j.name + "@" + j.version);
+  ' "$1" 2>/dev/null || true
+}
+
+extract_changelog_top() {
+  local file=$1
+  [[ -f "$file" ]] || return 0
+  awk '
+    /^## [0-9]/ { if (++s == 1) next; if (s > 1) exit }
+    s == 1 { print }
+  ' "$file"
+}
+
+regex_escape_basic() {
+  printf '%s' "$1" | sed 's/[][\\.^$*+?(){}|]/\\&/g'
+}
+
+assert_origin_is_github_com() {
+  local url
+  url=$(git config --get remote.origin.url 2>/dev/null || true)
+  if [[ -z "$url" ]]; then
+    url=$(git remote get-url origin 2>/dev/null || true)
+  fi
+  if [[ -z "$url" ]]; then
+    echo "runGithubReleaseTrain: no git remote named origin; cannot verify GitHub host." >&2
+    exit 1
+  fi
+  if [[ "$url" == git@github.com:* ]] \
+    || [[ "$url" == ssh://git@github.com/* ]] \
+    || [[ "$url" == https://github.com/* ]] \
+    || [[ "$url" == https://*@github.com/* ]] \
+    || [[ "$url" == http://github.com/* ]] \
+    || [[ "$url" == http://*@github.com/* ]]; then
+    return 0
+  fi
+  echo "runGithubReleaseTrain: origin must point at github.com for gh releases." >&2
+  echo "  url: ${url}" >&2
+  echo "  Fix origin, disable create-github-release, or use a github.com mirror for releases." >&2
+  exit 1
+}
+
+utc_calendar_date_str() {
+  if [[ -n "${UTC_DATE_OVERRIDE:-}" ]]; then
+    printf '%s' "$UTC_DATE_OVERRIDE"
+    return
+  fi
+  date -u +%Y.%m.%d
+}
+
+# stdin: git ls-remote --tags style lines; args: train_tag_prefix date_str
+max_n_from_ls_remote_for_date() {
+  local prefix=$1 date_str=$2 escaped_prefix escaped_date pattern line ref tag_suffix n max_n=-1
+  escaped_prefix=$(regex_escape_basic "$prefix")
+  escaped_date=$(regex_escape_basic "$date_str")
+  pattern="^${escaped_prefix}${escaped_date}\\.[0-9]+$"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -n "$line" ]] || continue
+    ref=$(awk '{print $2}' <<<"$line")
+    [[ "$ref" == refs/tags/* ]] || continue
+    ref=${ref#refs/tags/}
+    [[ "$ref" == *'^'* ]] && ref=${ref%^*}
+    [[ "$ref" =~ $pattern ]] || continue
+    tag_suffix=${ref#"$prefix"}
+    n=${tag_suffix##*.}
+    if [[ "$n" =~ ^[0-9]+$ ]] && [[ "$n" -gt "$max_n" ]]; then
+      max_n=$n
+    fi
+  done
+  if [[ "$max_n" -lt 0 ]]; then
+    printf '%s' "0"
+  else
+    printf '%s' "$max_n"
+  fi
+}
+
+compute_next_train_id_for_date() {
+  local prefix=$1 date_str=$2 ls_out max_n next_n
+  ls_out=$(git ls-remote --tags origin 2>/dev/null || true)
+  max_n=$(printf '%s\n' "$ls_out" | max_n_from_ls_remote_for_date "$prefix" "$date_str")
+  next_n=$((max_n + 1))
+  printf '%s' "${date_str}.${next_n}"
+}
+
+compute_next_train_id() {
+  compute_next_train_id_for_date "${TRAIN_TAG_PREFIX:-release/}" "$(utc_calendar_date_str)"
+}
+
+remote_train_tag_for_date_points_at_target() {
+  local prefix=$1 date_str=$2 target_sha=$3
+  local escaped_prefix escaped_date pattern line ref name peel
+  escaped_prefix=$(regex_escape_basic "$prefix")
+  escaped_date=$(regex_escape_basic "$date_str")
+  pattern="^${escaped_prefix}${escaped_date}\\.[0-9]+$"
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -n "$line" ]] || continue
+    ref=$(awk '{print $2}' <<<"$line")
+    [[ "$ref" == refs/tags/* ]] || continue
+    name=${ref#refs/tags/}
+    name=${name%^*}
+    [[ "$name" =~ $pattern ]] || continue
+    peel=$(remote_peeled_commit_for_tag "$name")
+    if [[ -n "$peel" && "$peel" == "$target_sha" ]]; then
+      return 0
+    fi
+  done < <(git ls-remote --tags origin 2>/dev/null || true)
+  return 1
+}
+
+list_merge_changelog_paths() {
+  git diff --name-only HEAD~1 HEAD 2>/dev/null | grep -E '(^|/)CHANGELOG\.md$' || true
+}
+
+truncate_notes_file() {
+  local out=$1 max=${2:-120000}
+  node -e 'const fs=require("fs");const p=process.argv[1];const m=+process.argv[2];let t=fs.readFileSync(p,"utf8");if(t.length>m){t=t.slice(0,m)+"\n\n_(body truncated for GitHub length limits)_\n";fs.writeFileSync(p,t);}' "$out" "$max" 2>/dev/null || true
+}
+
+build_release_notes_merge() {
+  local out=$1 cl dir pkg_json name excerpt
+  {
+    echo "## Changelog excerpts"
+    echo
+    echo "Automated release notes from Changesets publish merge (HEAD~1..HEAD CHANGELOG.md paths)."
+    echo
+  } >"$out"
+
+  while IFS= read -r cl; do
+    [[ -n "$cl" ]] || continue
+    [[ -f "$cl" ]] || continue
+    dir=$(dirname "$cl")
+    pkg_json="${dir}/package.json"
+    name=""
+    if [[ -f "$pkg_json" ]]; then
+      name=$(node -e 'const fs=require("fs"); const j=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); process.stdout.write(j.name||"")' "$pkg_json" 2>/dev/null || true)
+    fi
+    [[ -n "$name" ]] || name="$cl"
+    excerpt=$(extract_changelog_top "$cl" | head -n 200 || true)
+    {
+      echo "### ${name}"
+      echo
+      printf '%s\n' "$excerpt"
+      echo
+    } >>"$out"
+  done < <(list_merge_changelog_paths)
+
+  truncate_notes_file "$out"
+}
+
+prepend_notes_extra() {
+  local body=$1 extra=$2 merged
+  merged=$(mktemp)
+  {
+    if [[ -f "$extra" ]]; then
+      cat "$extra"
+      echo
+    fi
+    cat "$body"
+  } >"$merged"
+  mv "$merged" "$body"
+  truncate_notes_file "$body"
+}
+
+remote_peeled_commit_for_tag() {
+  local tag=$1 line
+  line=$(git ls-remote origin "refs/tags/${tag}^{}" | head -1 || true)
+  if [[ -n "$line" ]]; then
+    awk '{print $1}' <<<"$line"
+    return 0
+  fi
+  line=$(git ls-remote origin "refs/tags/${tag}" | head -1 || true)
+  if [[ -n "$line" ]]; then
+    awk '{print $1}' <<<"$line"
+    return 0
+  fi
+  printf ''
+}
+
+resolve_target_sha() {
+  local ref=$1
+  git rev-parse "${ref}^{commit}" 2>/dev/null || git rev-parse "$ref"
+}
+
+apply_title_template() {
+  local template=$1 logical=$2
+  printf '%s' "${template//\{\{logical_train_id\}\}/$logical}"
+}
+
+run_github_release_train_main() {
+  local app_dir prefix logical_id git_tag target_ref target_sha train_date_str notes_src body_file gh_err gh_extra=() remote_sha
+  local on_existing draft_lower pre_lower attempt notes_extra fail_notes
+
+  app_dir=${APP_DIR:-.}
+  cd "$app_dir"
+
+  assert_origin_is_github_com
+
+  if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    echo "runGithubReleaseTrain: GITHUB_TOKEN must be set for gh release create." >&2
+    exit 1
+  fi
+  export GH_TOKEN="$GITHUB_TOKEN"
+
+  prefix=${TRAIN_TAG_PREFIX:-release/}
+
+  target_ref=${TARGET_REF:-}
+  if [[ -z "$target_ref" ]]; then
+    target_ref=${CIRCLE_SHA1:-}
+  fi
+  if [[ -z "$target_ref" ]]; then
+    target_ref=HEAD
+  fi
+  target_sha=$(resolve_target_sha "$target_ref")
+
+  train_date_str=$(utc_calendar_date_str)
+  on_existing=${ON_EXISTING_TAG:-skip}
+  if remote_train_tag_for_date_points_at_target "$prefix" "$train_date_str" "$target_sha"; then
+    if [[ "$on_existing" == "skip" ]]; then
+      echo "runGithubReleaseTrain: a ${prefix}${train_date_str}.* tag already exists at ${target_sha}; skipping (on-existing-tag=skip)."
+      exit 0
+    fi
+    echo "runGithubReleaseTrain: a ${prefix}${train_date_str}.* tag already exists at the target commit (on-existing-tag=fail)." >&2
+    exit 1
+  fi
+
+  logical_id=$(compute_next_train_id_for_date "$prefix" "$train_date_str")
+  git_tag="${prefix}${logical_id}"
+
+  notes_src=${RELEASE_NOTES_SOURCE:-merge-commit}
+  body_file=$(mktemp)
+  gh_err=$(mktemp)
+  _cleanup_github_release_train_temps() {
+    rm -f "$gh_err"
+    if [[ "${GITHUB_RELEASE_TRAIN_KEEP_NOTES_FILE:-}" != "true" ]]; then
+      rm -f "$body_file"
+    fi
+  }
+  trap '_cleanup_github_release_train_temps' EXIT
+
+  notes_extra=${NOTES_EXTRA_FILE:-}
+  fail_notes="runGithubReleaseTrain: merge-commit mode requires at least one CHANGELOG.md path in git diff HEAD~1..HEAD (squash-merge the release PR so the merge commit parents include the prior tree)."
+
+  if [[ "$notes_src" == "body-file" ]]; then
+    if [[ -z "$notes_extra" || ! -f "$notes_extra" ]]; then
+      echo "runGithubReleaseTrain: release-notes-source=body-file requires notes-extra-file pointing at an existing file." >&2
+      exit 1
+    fi
+    cp "$notes_extra" "$body_file"
+    truncate_notes_file "$body_file"
+  else
+    if ! git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+      echo "runGithubReleaseTrain: need at least two commits for HEAD~1..HEAD changelog diff." >&2
+      exit 1
+    fi
+    mapfile -t _cl_paths < <(list_merge_changelog_paths)
+    if [[ ${#_cl_paths[@]} -eq 0 ]]; then
+      echo "runGithubReleaseTrain: no CHANGELOG.md paths in git diff HEAD~1..HEAD." >&2
+      echo "  ${fail_notes}" >&2
+      exit 1
+    fi
+    build_release_notes_merge "$body_file"
+    if [[ -n "$notes_extra" && -f "$notes_extra" ]]; then
+      prepend_notes_extra "$body_file" "$notes_extra"
+    fi
+  fi
+
+  draft_lower=$(printf '%s' "${DRAFT:-false}" | tr '[:upper:]' '[:lower:]')
+  pre_lower=$(printf '%s' "${PRERELEASE:-false}" | tr '[:upper:]' '[:lower:]')
+  [[ "$draft_lower" == "true" ]] || [[ "$draft_lower" == "1" ]] && gh_extra+=(--draft)
+  [[ "$pre_lower" == "true" ]] || [[ "$pre_lower" == "1" ]] && gh_extra+=(--prerelease)
+
+  title_template=${TITLE_TEMPLATE:-'{{logical_train_id}}'}
+  title=$(apply_title_template "$title_template" "$logical_id")
+
+  remote_sha=$(remote_peeled_commit_for_tag "$git_tag")
+  if [[ -n "$remote_sha" ]]; then
+    if [[ "$remote_sha" == "$target_sha" ]]; then
+      if [[ "$on_existing" == "skip" ]]; then
+        echo "runGithubReleaseTrain: tag ${git_tag} already exists at target ${target_sha}; skipping (on-existing-tag=skip)."
+        exit 0
+      fi
+      echo "runGithubReleaseTrain: tag ${git_tag} already exists at target but on-existing-tag=fail." >&2
+      exit 1
+    fi
+    echo "runGithubReleaseTrain: tag ${git_tag} exists on origin pointing at ${remote_sha}, not ${target_sha}." >&2
+    exit 1
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "runGithubReleaseTrain: gh CLI not found on PATH; run install-github-cli first." >&2
+    exit 1
+  fi
+
+  for attempt in 1 2; do
+    if gh release create "$git_tag" --target "$target_sha" --title "$title" --notes-file "$body_file" "${gh_extra[@]}" &>"$gh_err"; then
+      echo "runGithubReleaseTrain: created GitHub release ${git_tag} (title: ${title})."
+      exit 0
+    fi
+    cat "$gh_err" >&2 || true
+    if [[ "$attempt" -eq 1 ]] && grep -qiE 'already exists|HTTP 422|Validation Failed|tag_name|name already' "$gh_err" 2>/dev/null; then
+      echo "runGithubReleaseTrain: treating failure as possible tag/release race; recomputing train id (one retry)." >&2
+      logical_id=$(compute_next_train_id_for_date "$prefix" "$train_date_str")
+      git_tag="${prefix}${logical_id}"
+      title=$(apply_title_template "$title_template" "$logical_id")
+      remote_sha=$(remote_peeled_commit_for_tag "$git_tag")
+      if [[ -n "$remote_sha" && "$remote_sha" == "$target_sha" && "$on_existing" == "skip" ]]; then
+        echo "runGithubReleaseTrain: after retry, tag ${git_tag} already covers target; skipping."
+        exit 0
+      fi
+      : >"$gh_err"
+      continue
+    fi
+    exit 1
+  done
+}
+
+if [[ "${GITHUB_RELEASE_TRAIN_SOURCE_ONLY:-}" != "true" ]]; then
+  run_github_release_train_main "$@"
+fi

--- a/test/integration/changesetsPublishing.integration.bats
+++ b/test/integration/changesetsPublishing.integration.bats
@@ -60,4 +60,5 @@ setup() {
   assert_output --partial "changesets-gated-publish:"
   assert_output --partial "assert-release-merge:"
   assert_output --partial "install-github-cli:"
+  assert_output --partial "github-release-train:"
 }

--- a/test/runGithubReleaseTrain.bats
+++ b/test/runGithubReleaseTrain.bats
@@ -1,0 +1,281 @@
+#! /usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
+
+setup() {
+  load "helpers/setup"
+  _setup
+}
+
+_source_train_helpers() {
+  GITHUB_RELEASE_TRAIN_SOURCE_ONLY=true
+  # shellcheck disable=SC1091
+  source "$PROJECT_ROOT/src/scripts/runGithubReleaseTrain.sh"
+  export -f regex_escape_basic max_n_from_ls_remote_for_date utc_calendar_date_str apply_title_template
+}
+
+# Prints clone directory path to stdout (git noise redirected so command substitution stays clean).
+# origin is configured as a github.com URL (for assert-origin) with insteadOf so push/fetch/ls-remote use the bare repo.
+_github_train_init_clone() {
+  local parent bare clone bare_abs
+  parent=$(mktemp -d)
+  bare="${parent}/origin.git"
+  clone="${parent}/work"
+  git init --bare "$bare" >/dev/null 2>&1
+  mkdir -p "$clone"
+  git -C "$clone" init >/dev/null 2>&1
+  git -C "$clone" config user.email test@test
+  git -C "$clone" config user.name Test
+  bare_abs=$(cd "$(dirname "$bare")" && pwd)/$(basename "$bare")
+  git -C "$clone" remote add origin "https://github.com/example/test.git"
+  git -C "$clone" config url."file://${bare_abs}".insteadOf "https://github.com/example/test.git"
+  echo "base" >"${clone}/README.md"
+  git -C "$clone" add README.md
+  git -C "$clone" commit -m "init" >/dev/null 2>&1
+  git -C "$clone" branch -M master >/dev/null 2>&1
+  git -C "$clone" push -u origin master >/dev/null 2>&1
+  printf '%s' "$clone"
+}
+
+@test "max_n_from_ls_remote_for_date returns 0 when no matching tags" {
+  _source_train_helpers
+  run bash -c 'printf "%s\n" "deadbeef refs/tags/v1.0.0" | max_n_from_ls_remote_for_date "release/" "2026.05.08"'
+  assert_success
+  assert_output "0"
+}
+
+@test "max_n_from_ls_remote_for_date returns max N for prefix and UTC date" {
+  _source_train_helpers
+  run bash -c 'printf "%s\n" \
+    "a refs/tags/release/2026.05.08.1" \
+    "b refs/tags/release/2026.05.08.3^{}" \
+    "c refs/tags/release/2026.05.08.2" \
+    | max_n_from_ls_remote_for_date "release/" "2026.05.08"'
+  assert_success
+  assert_output "3"
+}
+
+@test "max_n_from_ls_remote_for_date supports empty train-tag-prefix" {
+  _source_train_helpers
+  run bash -c 'printf "%s\n" "a refs/tags/2099.01.01.7" | max_n_from_ls_remote_for_date "" "2099.01.01"'
+  assert_success
+  assert_output "7"
+}
+
+@test "apply_title_template replaces logical_train_id placeholder" {
+  _source_train_helpers
+  run bash -c 'apply_title_template "r-{{logical_train_id}}" "2099.01.01.2"'
+  assert_success
+  assert_output "r-2099.01.01.2"
+}
+
+@test "fails when merge diff has no CHANGELOG.md paths" {
+  local clone
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  clone=$(_github_train_init_clone)
+  cd "$clone" || exit 1
+  echo "two" >>README.md
+  git commit -am "second"
+  git push origin master
+
+  run env GITHUB_TOKEN=fake UTC_DATE_OVERRIDE=2099.01.01 \
+    bash "$PROJECT_ROOT/src/scripts/runGithubReleaseTrain.sh"
+  assert_failure
+  assert_output --partial "no CHANGELOG.md paths"
+}
+
+@test "fails when origin is not github.com" {
+  local clone
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  clone=$(_github_train_init_clone)
+  cd "$clone" || exit 1
+  mkdir -p pkg
+  printf '%s\n' '{"name":"@t/a","version":"1.0.0"}' >pkg/package.json
+  cat >pkg/CHANGELOG.md <<'EOF'
+## 1.0.0
+- x
+EOF
+  git add . && git commit -m "add changelog" && git push origin master
+  git remote set-url origin "https://gitlab.com/example/test.git"
+
+  run env GITHUB_TOKEN=fake UTC_DATE_OVERRIDE=2099.01.01 \
+    bash "$PROJECT_ROOT/src/scripts/runGithubReleaseTrain.sh"
+  assert_failure
+  assert_output --partial "github.com"
+}
+
+@test "on-existing-tag=skip exits 0 when train tag already exists at target" {
+  local clone sha
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  clone=$(_github_train_init_clone)
+  cd "$clone" || exit 1
+  mkdir -p pkg
+  printf '%s\n' '{"name":"@t/a","version":"1.0.0"}' >pkg/package.json
+  cat >pkg/CHANGELOG.md <<'EOF'
+## 1.0.0
+- x
+EOF
+  git add . && git commit -m "changelog" && git push origin master
+  sha=$(git rev-parse HEAD)
+
+  git -c tag.gpgSign=false tag -- "release/2099.01.01.1" "$sha"
+  git push origin "refs/tags/release/2099.01.01.1"
+
+  run env GITHUB_TOKEN=fake UTC_DATE_OVERRIDE=2099.01.01 ON_EXISTING_TAG=skip \
+    bash "$PROJECT_ROOT/src/scripts/runGithubReleaseTrain.sh"
+  assert_success
+  assert_output --partial "skipping"
+}
+
+@test "on-existing-tag=fail exits non-zero when train tag already exists at target" {
+  local clone sha
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  clone=$(_github_train_init_clone)
+  cd "$clone" || exit 1
+  mkdir -p pkg
+  printf '%s\n' '{"name":"@t/a","version":"1.0.0"}' >pkg/package.json
+  cat >pkg/CHANGELOG.md <<'EOF'
+## 1.0.0
+- x
+EOF
+  git add . && git commit -m "changelog" && git push origin master
+  sha=$(git rev-parse HEAD)
+
+  git -c tag.gpgSign=false tag -- "release/2099.01.01.1" "$sha"
+  git push origin "refs/tags/release/2099.01.01.1"
+
+  run env GITHUB_TOKEN=fake UTC_DATE_OVERRIDE=2099.01.01 ON_EXISTING_TAG=fail \
+    bash "$PROJECT_ROOT/src/scripts/runGithubReleaseTrain.sh"
+  assert_failure
+  assert_output --partial "on-existing-tag=fail"
+}
+
+@test "gh release create receives logical id as title and prefixed tag name" {
+  local clone bindir gh_mock
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  clone=$(_github_train_init_clone)
+  cd "$clone" || exit 1
+  mkdir -p pkg
+  printf '%s\n' '{"name":"@t/a","version":"1.0.0"}' >pkg/package.json
+  cat >pkg/CHANGELOG.md <<'EOF'
+## 1.0.0
+- x
+EOF
+  git add . && git commit -m "changelog" && git push origin master
+
+  gh_mock="$(mock_create)"
+  bindir=$(mktemp -d)
+  ln -sf "$gh_mock" "${bindir}/gh"
+
+  run env GITHUB_TOKEN=fake UTC_DATE_OVERRIDE=2099.01.01 \
+    PATH="${bindir}:$PATH" \
+    bash "$PROJECT_ROOT/src/scripts/runGithubReleaseTrain.sh"
+
+  assert_success
+  assert_equal "$(mock_get_call_num "$gh_mock")" "1"
+  args=$(mock_get_call_args "$gh_mock" 1)
+  [[ "$args" == *"--title"* ]] || false
+  [[ "$args" == *"2099.01.01.1"* ]] || false
+  [[ "$args" == *"release/2099.01.01.1"* ]] || false
+}
+
+@test "compute_next_train_id increments N when remote already has tags for UTC date" {
+  local clone bindir gh_mock sha_parent
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  clone=$(_github_train_init_clone)
+  cd "$clone" || exit 1
+  mkdir -p pkg
+  printf '%s\n' '{"name":"@t/a","version":"1.0.0"}' >pkg/package.json
+  cat >pkg/CHANGELOG.md <<'EOF'
+## 1.0.0
+- x
+EOF
+  git add . && git commit -m "changelog v1" && git push origin master
+  sha_parent=$(git rev-parse HEAD)
+
+  git -c tag.gpgSign=false tag -- "release/2099.01.01.1" "$sha_parent"
+  git push origin "refs/tags/release/2099.01.01.1"
+
+  cat >pkg/CHANGELOG.md <<'EOF'
+## 1.1.0
+- y
+EOF
+  git add . && git commit -m "changelog v2" && git push origin master
+
+  gh_mock="$(mock_create)"
+  bindir=$(mktemp -d)
+  ln -sf "$gh_mock" "${bindir}/gh"
+
+  run env GITHUB_TOKEN=fake UTC_DATE_OVERRIDE=2099.01.01 \
+    PATH="${bindir}:$PATH" \
+    bash "$PROJECT_ROOT/src/scripts/runGithubReleaseTrain.sh"
+
+  assert_success
+  args=$(mock_get_call_args "$gh_mock" 1)
+  [[ "$args" == *"release/2099.01.01.2"* ]] || false
+  [[ "$args" == *"2099.01.01.2"* ]] || false
+}
+
+@test "release-notes-source=body-file uses notes-extra-file without changelog diff" {
+  local clone bindir gh_mock notes
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  clone=$(_github_train_init_clone)
+  cd "$clone" || exit 1
+  echo "two" >>README.md
+  git commit -am "second"
+  git push origin master
+
+  notes=$(mktemp)
+  printf '%s\n' "manual body" >"$notes"
+
+  gh_mock="$(mock_create)"
+  bindir=$(mktemp -d)
+  ln -sf "$gh_mock" "${bindir}/gh"
+
+  run env GITHUB_TOKEN=fake UTC_DATE_OVERRIDE=2099.01.01 \
+    RELEASE_NOTES_SOURCE=body-file \
+    NOTES_EXTRA_FILE="$notes" \
+    PATH="${bindir}:$PATH" \
+    bash "$PROJECT_ROOT/src/scripts/runGithubReleaseTrain.sh"
+
+  assert_success
+  rm -f "$notes"
+}
+
+@test "merge-commit notes include package heading and changelog excerpt" {
+  local clone bindir gh_mock nf args
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  clone=$(_github_train_init_clone)
+  cd "$clone" || exit 1
+  mkdir -p pkg
+  printf '%s\n' '{"name":"@t/a","version":"1.0.0"}' >pkg/package.json
+  cat >pkg/CHANGELOG.md <<'EOF'
+## 1.0.0
+- init
+EOF
+  git add . && git commit -m "add pkg" && git push origin master
+
+  cat >pkg/CHANGELOG.md <<'EOF'
+## 1.1.0
+### Minor
+- ship it
+EOF
+  git add . && git commit -m "bump" && git push origin master
+
+  gh_mock="$(mock_create)"
+  bindir=$(mktemp -d)
+  ln -sf "$gh_mock" "${bindir}/gh"
+
+  run env GITHUB_TOKEN=fake UTC_DATE_OVERRIDE=2099.01.01 GITHUB_RELEASE_TRAIN_KEEP_NOTES_FILE=true \
+    PATH="${bindir}:$PATH" \
+    bash "$PROJECT_ROOT/src/scripts/runGithubReleaseTrain.sh"
+
+  assert_success
+  args=$(mock_get_call_args "$gh_mock" 1)
+  nf=$(printf '%s' "$args" | awk '{for(i=1;i<=NF;i++) if($i=="--notes-file"){print $(i+1); exit}}')
+  [[ -f "$nf" ]] || false
+  run grep -F "ship it" "$nf"
+  assert_success
+  run grep -F "@t/a" "$nf"
+  assert_success
+  rm -f "$nf"
+}


### PR DESCRIPTION
## Summary

Implements ADR 0037-style **GitHub Releases** after `changesets-gated-publish`: UTC logical train id `YYYY.MM.DD.N` as the release **title**, default git tag `release/YYYY.MM.DD.N`, notes from `HEAD~1..HEAD` `CHANGELOG.md` paths (empty diff fails fast), `origin` must be configured as `github.com`, bounded retry on conflict-like `gh` failures, and idempotent `on-existing-tag=skip` when a train tag for that UTC date already points at the target commit.

## Changes

- New `github-release-train` command + `runGithubReleaseTrain.sh`; `changesets-gated-publish` gains `create-github-release` (default `true`) and passthroughs; `install-github-cli` runs before the release step.
- Bats coverage + packed-orb integration assertion.
- Minor changeset for `@chiubaka/circleci-orb`; README publish flow; repo ADR 0001 consequence; org ADR 0037 and cross-links plus changesets-hygiene guidance.

## Opt-out

Consumers set `create-github-release: false` on `chiubaka/changesets-gated-publish` if they should not create GitHub Releases.

Made with [Cursor](https://cursor.com)