### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.17.0)

### DIFF
--- a/.changeset/github-release-train.md
+++ b/.changeset/github-release-train.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": minor
----
-
-`changesets-gated-publish` now defaults to creating a GitHub Release after publish: UTC train id `YYYY.MM.DD.N` as the release title, git tag `release/YYYY.MM.DD.N` by default, and notes from merged `CHANGELOG.md` diffs. Repos can set `create-github-release: false` to opt out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chiubaka/circleci-orb
 
+## 0.17.0
+
+### Minor Changes
+
+- e16d1b2: `changesets-gated-publish` now defaults to creating a GitHub Release after publish: UTC train id `YYYY.MM.DD.N` as the release title, git tag `release/YYYY.MM.DD.N` by default, and notes from merged `CHANGELOG.md` diffs. Repos can set `create-github-release: false` to opt out.
+
 ## 0.16.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.16.2",
+  "version": "0.17.0",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
## Changelog excerpts

Automated version bump via Changesets (release PR).

### @chiubaka/circleci-orb


### Minor Changes

- e16d1b2: `changesets-gated-publish` now defaults to creating a GitHub Release after publish: UTC train id `YYYY.MM.DD.N` as the release title, git tag `release/YYYY.MM.DD.N` by default, and notes from merged `CHANGELOG.md` diffs. Repos can set `create-github-release: false` to opt out.

