### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.17.1)

### DIFF
--- a/.changeset/grouped-release-notes-format.md
+++ b/.changeset/grouped-release-notes-format.md
@@ -1,9 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Group GitHub Release train and release PR bodies by Changesets bump category with published versions.
-
-Release notes and PR bodies now use Major / Minor / Patch sections, one package bullet per section with nested change bullets, and a Published versions list. Consumer CircleCI jobs stage the formatter via a dedicated script because orb `include` must be the entire command string.
-
-A Bats test asserts the staged formatter body stays byte-identical to `formatChangesetsBatchReleaseNotes.mjs`. Package metadata used by the formatter exposes only `name` and `published`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @chiubaka/circleci-orb
 
+## 0.17.1
+
+### Patch Changes
+
+- c45aabd: Group GitHub Release train and release PR bodies by Changesets bump category with published versions.
+
+  Release notes and PR bodies now use Major / Minor / Patch sections, one package bullet per section with nested change bullets, and a Published versions list. Consumer CircleCI jobs stage the formatter via a dedicated script because orb `include` must be the entire command string.
+
+  A Bats test asserts the staged formatter body stays byte-identical to `formatChangesetsBatchReleaseNotes.mjs`. Package metadata used by the formatter exposes only `name` and `published`.
+
 ## 0.17.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### Patch Changes

- **@chiubaka/circleci-orb**
  - c45aabd: Group GitHub Release train and release PR bodies by Changesets bump category with published versions.

      Release notes and PR bodies now use Major / Minor / Patch sections, one package bullet per section with nested change bullets, and a Published versions list. Consumer CircleCI jobs stage the formatter via a dedicated script because orb `include` must be the entire command string.

      A Bats test asserts the staged formatter body stays byte-identical to `formatChangesetsBatchReleaseNotes.mjs`. Package metadata used by the formatter exposes only `name` and `published`.

## Published versions

- `@chiubaka/circleci-orb@0.17.1`
