### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.18.0)

### DIFF
--- a/.changeset/fix-codecov-cli-gpg-keybase-account.md
+++ b/.changeset/fix-codecov-cli-gpg-keybase-account.md
@@ -1,7 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix Codecov CLI GPG verification by importing the PGP key from the current keybase account (`codecovsecops`).
-
-The previous keybase account was retired and returned no key, which caused the `test` job coverage upload step to fail GPG signature verification.

--- a/.changeset/release-manifest-coordinated-deploy.md
+++ b/.changeset/release-manifest-coordinated-deploy.md
@@ -1,7 +1,0 @@
----
-"@chiubaka/circleci-orb": minor
----
-
-Add release manifest support and coordinated deploy for application monorepos.
-
-Introduces a shared UTC train id module, opt-in `create-release-manifest` on the changesets release PR job, `verify-release-manifest`, commit-primary `coordinated-deploy`, and optional `promotion-tag-prefix` on gated publish. Library consumers keep prior defaults with no required config changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @chiubaka/circleci-orb
 
+## 0.18.0
+
+### Minor Changes
+
+- c5cba08: Add release manifest support and coordinated deploy for application monorepos.
+
+  Introduces a shared UTC train id module, opt-in `create-release-manifest` on the changesets release PR job, `verify-release-manifest`, commit-primary `coordinated-deploy`, and optional `promotion-tag-prefix` on gated publish. Library consumers keep prior defaults with no required config changes.
+
+### Patch Changes
+
+- 82d7f77: Fix Codecov CLI GPG verification by importing the PGP key from the current keybase account (`codecovsecops`).
+
+  The previous keybase account was retired and returned no key, which caused the `test` job coverage upload step to fail GPG signature verification.
+
 ## 0.17.1
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.17.1",
+  "version": "0.18.0",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### Minor Changes

- **@chiubaka/circleci-orb**
  - c5cba08: Add release manifest support and coordinated deploy for application monorepos.

      Introduces a shared UTC train id module, opt-in `create-release-manifest` on the changesets release PR job, `verify-release-manifest`, commit-primary `coordinated-deploy`, and optional `promotion-tag-prefix` on gated publish. Library consumers keep prior defaults with no required config changes.

### Patch Changes

- **@chiubaka/circleci-orb**
  - 82d7f77: Fix Codecov CLI GPG verification by importing the PGP key from the current keybase account (`codecovsecops`).

      The previous keybase account was retired and returned no key, which caused the `test` job coverage upload step to fail GPG signature verification.

## Published versions

- `@chiubaka/circleci-orb@0.18.0`
