### PR TITLE
fix(codecov): import PGP key from current keybase account

### DIFF
--- a/.changeset/fix-codecov-cli-gpg-keybase-account.md
+++ b/.changeset/fix-codecov-cli-gpg-keybase-account.md
@@ -1,0 +1,7 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fix Codecov CLI GPG verification by importing the PGP key from the current keybase account (`codecovsecops`).
+
+The previous keybase account was retired and returned no key, which caused the `test` job coverage upload step to fail GPG signature verification.

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -70,7 +70,7 @@ codecov_validate_cli() {
 
   if ! (
     cd "$install_dir" || exit 1
-    curl -s https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --import
+    curl -fsS "${curl_retry[@]}" --connect-timeout 2 https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --import
     local base sha_url
     base="${CODECOV_CLI_URL:-https://cli.codecov.io}"
     base="${base}/${CODECOV_VERSION:-latest}/${CODECOV_OS?}"

--- a/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
+++ b/src/scripts/uploadMonorepoCoverageWithCodecovCli.sh
@@ -70,7 +70,7 @@ codecov_validate_cli() {
 
   if ! (
     cd "$install_dir" || exit 1
-    curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --import
+    curl -s https://keybase.io/codecovsecops/pgp_keys.asc | gpg --no-default-keyring --import
     local base sha_url
     base="${CODECOV_CLI_URL:-https://cli.codecov.io}"
     base="${base}/${CODECOV_VERSION:-latest}/${CODECOV_OS?}"

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -402,7 +402,7 @@ EOF
   cat >"$mock_bin_dir/curl" <<'EOF'
 #! /usr/bin/env bash
 last="${@: -1}"
-if [[ "$1" == "-s" && "$2" == "https://keybase.io/codecovsecurity/pgp_keys.asc" ]]; then
+if [[ "$1" == "-s" && "$2" == "https://keybase.io/codecovsecops/pgp_keys.asc" ]]; then
   printf 'fake-key'
   exit 0
 fi

--- a/test/uploadMonorepoCoverageWithCodecovCli.bats
+++ b/test/uploadMonorepoCoverageWithCodecovCli.bats
@@ -402,7 +402,7 @@ EOF
   cat >"$mock_bin_dir/curl" <<'EOF'
 #! /usr/bin/env bash
 last="${@: -1}"
-if [[ "$1" == "-s" && "$2" == "https://keybase.io/codecovsecops/pgp_keys.asc" ]]; then
+if [[ "$*" == *"https://keybase.io/codecovsecops/pgp_keys.asc"* ]]; then
   printf 'fake-key'
   exit 0
 fi


### PR DESCRIPTION
## Summary
- Update Codecov CLI GPG verification to import the PGP key from `codecovsecops` instead of the retired keybase account, which returned no key and caused every `test` job to fail at the coverage upload step.
- Align the bats curl mock with the corrected key URL.
- Add a patch changeset for `@chiubaka/circleci-orb` (0.17.1 → 0.17.2).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (115/115, including `uploadMonorepoCoverageWithCodecovCli`)
- [x] Live key endpoint returns `-----BEGIN PGP PUBLIC KEY BLOCK-----`
- [ ] After orb publish, confirm a consumer `test` job completes "Upload monorepo coverage per package using Codecov CLI" without GPG errors


Made with [Cursor](https://cursor.com)