### PR TITLE
feat(compute-changesets): forward PR metadata to continuation parameters

### DIFF
--- a/.changeset/compute-changesets-pr-metadata.md
+++ b/.changeset/compute-changesets-pr-metadata.md
@@ -1,0 +1,7 @@
+---
+"@chiubaka/circleci-orb": minor
+---
+
+Add optional `include-pr-metadata` on `compute-changesets-publish-parameters` to forward `circle_pull_request` and `circle_pr_number` into continuation pipeline parameters.
+
+CircleCI setup workflows do not propagate `CIRCLE_PULL_REQUEST` / `CIRCLE_PR_NUMBER` into continuation pipelines; opt in when downstream jobs (for example Codecov PR association) need that context.

--- a/.changeset/compute-changesets-pr-metadata.md
+++ b/.changeset/compute-changesets-pr-metadata.md
@@ -2,6 +2,6 @@
 "@chiubaka/circleci-orb": minor
 ---
 
-Add optional `include-pr-metadata` on `compute-changesets-publish-parameters` to forward `circle_pull_request` and `circle_pr_number` into continuation pipeline parameters.
+Feature: Add optional `include-pr-metadata` for PR continuation parameters.
 
 CircleCI setup workflows do not propagate `CIRCLE_PULL_REQUEST` / `CIRCLE_PR_NUMBER` into continuation pipelines; opt in when downstream jobs (for example Codecov PR association) need that context.

--- a/src/commands/compute-changesets-publish-parameters.yml
+++ b/src/commands/compute-changesets-publish-parameters.yml
@@ -3,8 +3,11 @@ description: >
   from git diff against origin/<base-revision>, matching release-related paths (CHANGELOG.md or
   package.json top-level version changes). Pair with circleci/continuation continue (optional
   pipeline parameter run-changesets-publish) and/or a gated-publish job pre-step that reads the same
-  JSON. Requires git, jq, and fetch access to origin. Install jq first (for example circleci/jq
-  jq/install) when using minimal images such as cimg/base.
+  JSON. Optionally forward CIRCLE_PULL_REQUEST and CIRCLE_PR_NUMBER as continuation pipeline
+  parameters (include-pr-metadata) because setup workflows do not propagate those env vars into
+  continuation pipelines (for example Codecov PR association). Requires git, jq, and fetch access to
+  origin. Install jq first (for example circleci/jq jq/install) when using minimal images such as
+  cimg/base.
 
 parameters:
   base-revision:
@@ -19,6 +22,13 @@ parameters:
     type: boolean
     default: true
     description: When false, skip publish flag when merge-base equals CIRCLE_SHA1 (path-filtering style).
+  include-pr-metadata:
+    type: boolean
+    default: false
+    description: >
+      When true, also write circle_pull_request and circle_pr_number (empty string when unset) for
+      continuation pipeline.parameters. CIRCLE_PR_NUMBER falls back to the trailing path segment of
+      CIRCLE_PULL_REQUEST when the number env var is empty.
 
 steps:
   - run:
@@ -27,4 +37,5 @@ steps:
         BASE_REVISION: << parameters.base-revision >>
         OUTPUT_PATH: << parameters.output-path >>
         SAME_BASE_RUN: << parameters.same-base-run >>
+        INCLUDE_PR_METADATA: << parameters.include-pr-metadata >>
       command: << include(scripts/computeChangesetsPublishParameters.sh) >>

--- a/src/examples/changesets-gated-publish-path-filtering.yml
+++ b/src/examples/changesets-gated-publish-path-filtering.yml
@@ -26,6 +26,7 @@ usage:
         - jq/install
         - chiubaka/compute-changesets-publish-parameters:
             base-revision: master
+            # include-pr-metadata: true  # forward CIRCLE_PULL_REQUEST / CIRCLE_PR_NUMBER to continuation
         - continuation/continue:
             configuration_path: .circleci/continue_config.yml
             parameters: /tmp/pipeline-parameters.json
@@ -44,6 +45,12 @@ usage:
   #     run-changesets-publish:
   #       type: boolean
   #       default: false
+  #     circle_pull_request:
+  #       type: string
+  #       default: ""
+  #     circle_pr_number:
+  #       type: string
+  #       default: ""
   #   orbs:
   #     chiubaka: chiubaka/circleci-orb@0.15.0
   #   workflows:

--- a/src/scripts/computeChangesetsPublishParameters.sh
+++ b/src/scripts/computeChangesetsPublishParameters.sh
@@ -6,14 +6,47 @@
 #   - any CHANGELOG.md path changed in the diff, or
 #   - any package.json had its top-level "version" field value change (including new files).
 #
+# Optional INCLUDE_PR_METADATA=true merges circle_pull_request and circle_pr_number for consumers
+# whose continuation pipelines need PR context (CircleCI does not propagate CIRCLE_PULL_REQUEST).
+#
 # Environment: CIRCLE_SHA1 (required), BASE_REVISION (default master), OUTPUT_PATH (default
-# /tmp/pipeline-parameters.json), SAME_BASE_RUN (default true).
+# /tmp/pipeline-parameters.json), SAME_BASE_RUN (default true), INCLUDE_PR_METADATA (default false).
 set -euo pipefail
 
 OUTPUT_PATH="${OUTPUT_PATH:-/tmp/pipeline-parameters.json}"
 BASE_REVISION="${BASE_REVISION:-master}"
 same_base_raw="${SAME_BASE_RUN:-true}"
 SAME_BASE_RUN_LOWER=$(printf '%s' "$same_base_raw" | tr '[:upper:]' '[:lower:]')
+include_pr_metadata_raw="${INCLUDE_PR_METADATA:-false}"
+INCLUDE_PR_METADATA_LOWER=$(printf '%s' "$include_pr_metadata_raw" | tr '[:upper:]' '[:lower:]')
+
+include_pr_metadata_enabled() {
+  [[ "$INCLUDE_PR_METADATA_LOWER" == "true" ]] || [[ "$include_pr_metadata_raw" == "1" ]]
+}
+
+write_pipeline_parameters() {
+  local publish_bool="$1"
+  local json
+  json=$(jq -nc --argjson flag "$publish_bool" '{"run-changesets-publish": $flag}')
+
+  if include_pr_metadata_enabled; then
+    local pull_request="${CIRCLE_PULL_REQUEST:-}"
+    local pr_number="${CIRCLE_PR_NUMBER:-}"
+    if [[ -z "$pr_number" && -n "$pull_request" ]]; then
+      pr_number="${pull_request##*/}"
+    fi
+    json=$(
+      jq -c --arg pull_request "$pull_request" --arg pr_number "$pr_number" \
+        '. + {circle_pull_request: $pull_request, circle_pr_number: $pr_number}' <<<"$json"
+    )
+  fi
+
+  if [[ -f "$OUTPUT_PATH" ]]; then
+    json=$(jq -cs '.[0] * .[1]' "$OUTPUT_PATH" <(printf '%s' "$json"))
+  fi
+
+  printf '%s\n' "$json" >"$OUTPUT_PATH"
+}
 
 : "${CIRCLE_SHA1:?CIRCLE_SHA1 is required}"
 
@@ -28,14 +61,14 @@ if ! MERGE_BASE=$(git merge-base "origin/${BASE_REVISION}" "$CIRCLE_SHA1" 2>/dev
   fi
 fi
 if ! MERGE_BASE=$(git merge-base "origin/${BASE_REVISION}" "$CIRCLE_SHA1" 2>/dev/null) || [[ -z "$MERGE_BASE" ]]; then
-  echo '{"run-changesets-publish": false}' >"$OUTPUT_PATH"
+  write_pipeline_parameters false
   echo "Unable to compute merge-base for origin/${BASE_REVISION} and ${CIRCLE_SHA1}: wrote false to ${OUTPUT_PATH}" >&2
   exit 0
 fi
 
 if [[ "$MERGE_BASE" == "$CIRCLE_SHA1" ]]; then
   if [[ "$SAME_BASE_RUN_LOWER" != "true" ]] && [[ "$same_base_raw" != "1" ]]; then
-    echo '{"run-changesets-publish": false}' >"$OUTPUT_PATH"
+    write_pipeline_parameters false
     echo "Same revision as base (SAME_BASE_RUN disallows same-base run): wrote false to ${OUTPUT_PATH}"
     exit 0
   fi
@@ -51,7 +84,7 @@ if [[ "$MERGE_BASE" == "$CIRCLE_SHA1" ]]; then
     if git rev-parse "${CIRCLE_SHA1}~1" >/dev/null 2>&1; then
       PREVIOUS_REVISION=$(git rev-parse "${CIRCLE_SHA1}~1")
     else
-      echo '{"run-changesets-publish": false}' >"$OUTPUT_PATH"
+      write_pipeline_parameters false
       echo "Unable to resolve previous revision for ${CIRCLE_SHA1}: wrote false to ${OUTPUT_PATH}" >&2
       exit 0
     fi
@@ -96,9 +129,9 @@ if [[ "$publish" != "true" ]]; then
 fi
 
 if [[ "$publish" == "true" ]]; then
-  echo '{"run-changesets-publish": true}' >"$OUTPUT_PATH"
+  write_pipeline_parameters true
 else
-  echo '{"run-changesets-publish": false}' >"$OUTPUT_PATH"
+  write_pipeline_parameters false
 fi
 
 echo "Wrote $(cat "$OUTPUT_PATH") to ${OUTPUT_PATH}"

--- a/test/computeChangesetsPublishParameters.bats
+++ b/test/computeChangesetsPublishParameters.bats
@@ -32,14 +32,19 @@ create_repo_with_remote() {
 }
 
 run_compute_script() {
-  local repo_dir
-  local output_path
-  repo_dir="$1"
-  output_path="$repo_dir/out.json"
-  CIRCLE_SHA1="$(git -C "$repo_dir" rev-parse HEAD)" \
-    BASE_REVISION=master \
-    OUTPUT_PATH="$output_path" \
-    bash -c "cd \"$repo_dir\" && bash \"$PROJECT_ROOT/src/scripts/computeChangesetsPublishParameters.sh\" >/dev/null"
+  local repo_dir="$1"
+  shift
+  local output_path="$repo_dir/out.json"
+  local -a env_args=(
+    "CIRCLE_SHA1=$(git -C "$repo_dir" rev-parse HEAD)"
+    BASE_REVISION=master
+    "OUTPUT_PATH=$output_path"
+  )
+  while (($# > 0)); do
+    env_args+=("$1")
+    shift
+  done
+  env "${env_args[@]}" bash -c "cd \"$repo_dir\" && bash \"$PROJECT_ROOT/src/scripts/computeChangesetsPublishParameters.sh\" >/dev/null"
   cat "$output_path"
 }
 
@@ -50,7 +55,7 @@ run_compute_script() {
   git -C "$repo_dir" commit -m "docs: changelog update" >/dev/null
 
   result="$(run_compute_script "$repo_dir")"
-  assert_equal "$result" '{"run-changesets-publish": true}'
+  assert_equal "$result" '{"run-changesets-publish":true}'
 }
 
 @test "returns true when package version field changes" {
@@ -60,7 +65,7 @@ run_compute_script() {
   git -C "$repo_dir" commit -m "feat: bump version" >/dev/null
 
   result="$(run_compute_script "$repo_dir")"
-  assert_equal "$result" '{"run-changesets-publish": true}'
+  assert_equal "$result" '{"run-changesets-publish":true}'
 }
 
 @test "returns false when no changelog or version changes exist" {
@@ -70,7 +75,7 @@ run_compute_script() {
   git -C "$repo_dir" commit -m "docs: add readme" >/dev/null
 
   result="$(run_compute_script "$repo_dir")"
-  assert_equal "$result" '{"run-changesets-publish": false}'
+  assert_equal "$result" '{"run-changesets-publish":false}'
 }
 
 @test "recovers from shallow clone merge-base failure path" {
@@ -109,5 +114,75 @@ run_compute_script() {
 
   assert_success
   run cat "$output_path"
-  assert_output '{"run-changesets-publish": true}'
+  assert_output '{"run-changesets-publish":true}'
+}
+
+@test "omits PR metadata by default" {
+  repo_dir="$(create_repo_with_remote)"
+  printf '%s\n' 'notes' >"$repo_dir/README.md"
+  git -C "$repo_dir" add README.md
+  git -C "$repo_dir" commit -m "docs: add readme" >/dev/null
+
+  result="$(
+    run_compute_script "$repo_dir" \
+      CIRCLE_PULL_REQUEST='https://github.com/org/repo/pull/42' \
+      CIRCLE_PR_NUMBER='42'
+  )"
+  assert_equal "$result" '{"run-changesets-publish":false}'
+}
+
+@test "includes PR metadata when enabled" {
+  repo_dir="$(create_repo_with_remote)"
+  printf '%s\n' 'notes' >"$repo_dir/README.md"
+  git -C "$repo_dir" add README.md
+  git -C "$repo_dir" commit -m "docs: add readme" >/dev/null
+
+  result="$(
+    run_compute_script "$repo_dir" \
+      CIRCLE_PULL_REQUEST='https://github.com/org/repo/pull/42' \
+      CIRCLE_PR_NUMBER='42' \
+      INCLUDE_PR_METADATA=true
+  )"
+  assert_equal "$result" '{"run-changesets-publish":false,"circle_pull_request":"https://github.com/org/repo/pull/42","circle_pr_number":"42"}'
+}
+
+@test "derives PR number from pull request URL when number env is empty" {
+  repo_dir="$(create_repo_with_remote)"
+  printf '%s\n' 'notes' >"$repo_dir/README.md"
+  git -C "$repo_dir" add README.md
+  git -C "$repo_dir" commit -m "docs: add readme" >/dev/null
+
+  result="$(
+    run_compute_script "$repo_dir" \
+      CIRCLE_PULL_REQUEST='https://github.com/org/repo/pull/99' \
+      INCLUDE_PR_METADATA=true
+  )"
+  assert_equal "$result" '{"run-changesets-publish":false,"circle_pull_request":"https://github.com/org/repo/pull/99","circle_pr_number":"99"}'
+}
+
+@test "emits empty PR metadata strings when env vars are unset" {
+  repo_dir="$(create_repo_with_remote)"
+  printf '%s\n' 'notes' >"$repo_dir/README.md"
+  git -C "$repo_dir" add README.md
+  git -C "$repo_dir" commit -m "docs: add readme" >/dev/null
+
+  result="$(run_compute_script "$repo_dir" INCLUDE_PR_METADATA=true)"
+  assert_equal "$result" '{"run-changesets-publish":false,"circle_pull_request":"","circle_pr_number":""}'
+}
+
+@test "merges computed parameters into an existing output file" {
+  repo_dir="$(create_repo_with_remote)"
+  output_path="$repo_dir/out.json"
+  printf '%s\n' '{"custom-parameter": "keep"}' >"$output_path"
+  printf '%s\n' 'notes' >"$repo_dir/README.md"
+  git -C "$repo_dir" add README.md
+  git -C "$repo_dir" commit -m "docs: add readme" >/dev/null
+
+  result="$(
+    run_compute_script "$repo_dir" \
+      CIRCLE_PULL_REQUEST='https://github.com/org/repo/pull/7' \
+      CIRCLE_PR_NUMBER='7' \
+      INCLUDE_PR_METADATA=true
+  )"
+  assert_equal "$result" '{"custom-parameter":"keep","run-changesets-publish":false,"circle_pull_request":"https://github.com/org/repo/pull/7","circle_pr_number":"7"}'
 }

--- a/test/computeChangesetsPublishParameters.bats
+++ b/test/computeChangesetsPublishParameters.bats
@@ -155,6 +155,7 @@ run_compute_script() {
   result="$(
     run_compute_script "$repo_dir" \
       CIRCLE_PULL_REQUEST='https://github.com/org/repo/pull/99' \
+      CIRCLE_PR_NUMBER='' \
       INCLUDE_PR_METADATA=true
   )"
   assert_equal "$result" '{"run-changesets-publish":false,"circle_pull_request":"https://github.com/org/repo/pull/99","circle_pr_number":"99"}'
@@ -166,7 +167,12 @@ run_compute_script() {
   git -C "$repo_dir" add README.md
   git -C "$repo_dir" commit -m "docs: add readme" >/dev/null
 
-  result="$(run_compute_script "$repo_dir" INCLUDE_PR_METADATA=true)"
+  result="$(
+    run_compute_script "$repo_dir" \
+      CIRCLE_PULL_REQUEST='' \
+      CIRCLE_PR_NUMBER='' \
+      INCLUDE_PR_METADATA=true
+  )"
   assert_equal "$result" '{"run-changesets-publish":false,"circle_pull_request":"","circle_pr_number":""}'
 }
 


### PR DESCRIPTION
## Summary
- Add opt-in `include-pr-metadata` to `compute-changesets-publish-parameters` so setup workflows can forward `circle_pull_request` and `circle_pr_number` into continuation pipeline parameters.
- CircleCI does not propagate `CIRCLE_PULL_REQUEST` / `CIRCLE_PR_NUMBER` into continuation pipelines; this removes the downstream `jq` merge boilerplate needed for Codecov PR association and similar use cases.
- Default behavior is unchanged (`include-pr-metadata: false`); when enabled, PR fields are emitted as empty strings when unset, with PR number derived from the URL trailing segment when needed.

## Test plan
- [x] `pnpm test` (including new bats cases for default, enabled, URL fallback, empty values, and merge-with-existing file)
- [x] `pnpm lint`
- [ ] Verify continuation config declares `circle_pull_request` / `circle_pr_number` pipeline parameters when adopting the flag


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `include-pr-metadata` setting to include pull request context in generated pipeline parameters.
  * When enabled, forwards pull request URL and number (with derived number/fallbacks) into the continuation parameters.
* **Bug Fixes**
  * Existing pipeline-parameter output is now merged safely when an output file already exists.
* **Documentation**
  * Expanded setup/usage guidance to clarify prerequisites for execution in minimal environments.
* **Tests**
  * Updated and expanded coverage for default/flag-driven PR-metadata behavior and JSON merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->