### PR TITLE
fix(changesets): recognize category prefixes after commit annotations

### DIFF
--- a/.changeset/fix-changelog-category-prefix-annotations.md
+++ b/.changeset/fix-changelog-category-prefix-annotations.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fix: Recognize category prefixes on changelog bullets that include Changesets commit annotations (`<shortSha>: `).

--- a/.changeset/fix-changelog-category-prefix-annotations.md
+++ b/.changeset/fix-changelog-category-prefix-annotations.md
@@ -2,4 +2,4 @@
 "@chiubaka/circleci-orb": patch
 ---
 
-Fix: Recognize category prefixes on changelog bullets that include Changesets commit annotations (`<shortSha>: `).
+Fix: Recognize category prefixes on changelog bullets that include Changesets commit annotations (`<shortSha>:` prefixes).

--- a/src/scripts/changesetCategoryPrefixes.mjs
+++ b/src/scripts/changesetCategoryPrefixes.mjs
@@ -119,6 +119,65 @@ export function stripCategoryPrefix(text) {
 }
 
 /**
+ * Strip Changesets changelog bullet metadata before category matching.
+ * `@changesets/cli/changelog` re-exports `@changesets/changelog-git`, which prefixes bullets with
+ * `<shortSha>: ` when a changeset commit is known. `@changesets/changelog-github` may prefix with
+ * PR/commit links and a `Thanks …! - ` segment before the summary headline.
+ *
+ * @param {string} text Changelog bullet text after the list marker (`- `).
+ * @returns {string} Headline suitable for {@link classifyCategoryToken}.
+ */
+export function stripChangelogBulletAnnotations(text) {
+  let t = String(text).trim();
+  if (classifyCategoryToken(t) !== null) return t;
+
+  const github = t.match(/^[\s\S]+?\s+-\s+([\s\S]+)$/);
+  if (github) {
+    const candidate = github[1].trim();
+    if (classifyCategoryToken(candidate) !== null) return candidate;
+  }
+
+  const git = t.match(/^[0-9a-f]{7,40}\s*:\s*([\s\S]+)$/i);
+  if (git) {
+    const candidate = git[1].trim();
+    if (classifyCategoryToken(candidate) !== null) return candidate;
+  }
+
+  const linkedCommit = t.match(
+    /^\[(?:`)?[0-9a-f]{7,40}(?:`)?\]\([^)]+\)\s*:?\s*([\s\S]+)$/i,
+  );
+  if (linkedCommit) {
+    const candidate = linkedCommit[1].trim();
+    if (classifyCategoryToken(candidate) !== null) return candidate;
+  }
+
+  let prev;
+  do {
+    prev = t;
+    t = t.replace(/^\[[^\]]+\]\([^)]+\)\s+/i, "").trim();
+    if (classifyCategoryToken(t) !== null) return t;
+  } while (t !== prev);
+
+  return String(text).trim();
+}
+
+/**
+ * @param {string} text Changelog bullet text after the list marker (`- `).
+ * @returns {CategoryBucket | null}
+ */
+export function classifyChangelogBullet(text) {
+  return classifyCategoryToken(stripChangelogBulletAnnotations(text));
+}
+
+/**
+ * @param {string} text Changelog bullet text after the list marker (`- `).
+ * @returns {string}
+ */
+export function stripChangelogBulletCategoryPrefix(text) {
+  return stripCategoryPrefix(stripChangelogBulletAnnotations(text));
+}
+
+/**
  * @param {string} content Full changeset markdown file contents.
  * @returns {{ ok: true, headline: string, bucket: CategoryBucket } | { ok: false, error: string }}
  */

--- a/src/scripts/formatChangesetsBatchReleaseNotes.mjs
+++ b/src/scripts/formatChangesetsBatchReleaseNotes.mjs
@@ -44,8 +44,7 @@ const BUMP_TYPE_CONFIG = {
 };
 
 function buildCategoryConfig(prefixes) {
-  const { classifyCategoryToken, CATEGORY_ORDER, CATEGORY_SECTION_TITLE, CATEGORY_TOKEN_RE } =
-    prefixes;
+  const { classifyChangelogBullet, CATEGORY_ORDER, CATEGORY_SECTION_TITLE } = prefixes;
   return {
     order: CATEGORY_ORDER,
     titles: CATEGORY_SECTION_TITLE,
@@ -65,7 +64,7 @@ function buildCategoryConfig(prefixes) {
       const first = block[0];
       const m = String(first).match(/^[-*]\s?(.*)$/);
       const text = m ? m[1] : String(first).replace(/^[-*]\s?/, "");
-      return classifyCategoryToken(text);
+      return classifyChangelogBullet(text);
     },
   };
 }
@@ -203,7 +202,7 @@ function parseVersionBody(bodyLines, config) {
 
 function emitNestedUnderPackage(blocks, prefixes) {
   const out = [];
-  const stripFn = prefixes?.stripCategoryPrefix ?? ((t) => t);
+  const stripFn = prefixes?.stripChangelogBulletCategoryPrefix ?? ((t) => t);
   for (const block of blocks) {
     if (!block || block.length === 0) continue;
     const first = block[0];

--- a/src/scripts/rewriteChangelogCategories.mjs
+++ b/src/scripts/rewriteChangelogCategories.mjs
@@ -126,18 +126,21 @@ function collectUntilNextHeading(lines, start) {
 }
 
 function collectBlocksFromBody(bodyLines, prefixes) {
-  const { classifyCategoryToken, CATEGORY_ORDER, stripCategoryPrefix } = prefixes;
+  const { classifyChangelogBullet, CATEGORY_ORDER, stripChangelogBulletCategoryPrefix } =
+    prefixes;
   /** @type {Record<string, string[][][]>} */
   const buckets = Object.fromEntries(CATEGORY_ORDER.map((key) => [key, []]));
   const unclassified = [];
 
   function addBlocks(blocks) {
     for (const block of blocks) {
-      const bucket = classifyCategoryToken(bulletSummaryText(block));
+      const bucket = classifyChangelogBullet(bulletSummaryText(block));
       if (bucket === null) {
         unclassified.push(block);
       } else {
-        buckets[bucket].push(stripCategoryTokenFromBlock(block, stripCategoryPrefix));
+        buckets[bucket].push(
+          stripCategoryTokenFromBlock(block, stripChangelogBulletCategoryPrefix),
+        );
       }
     }
   }

--- a/src/scripts/stageChangesetCategoryPrefixScripts.sh
+++ b/src/scripts/stageChangesetCategoryPrefixScripts.sh
@@ -127,6 +127,65 @@ export function stripCategoryPrefix(text) {
 }
 
 /**
+ * Strip Changesets changelog bullet metadata before category matching.
+ * `@changesets/cli/changelog` re-exports `@changesets/changelog-git`, which prefixes bullets with
+ * `<shortSha>: ` when a changeset commit is known. `@changesets/changelog-github` may prefix with
+ * PR/commit links and a `Thanks …! - ` segment before the summary headline.
+ *
+ * @param {string} text Changelog bullet text after the list marker (`- `).
+ * @returns {string} Headline suitable for {@link classifyCategoryToken}.
+ */
+export function stripChangelogBulletAnnotations(text) {
+  let t = String(text).trim();
+  if (classifyCategoryToken(t) !== null) return t;
+
+  const github = t.match(/^[\s\S]+?\s+-\s+([\s\S]+)$/);
+  if (github) {
+    const candidate = github[1].trim();
+    if (classifyCategoryToken(candidate) !== null) return candidate;
+  }
+
+  const git = t.match(/^[0-9a-f]{7,40}\s*:\s*([\s\S]+)$/i);
+  if (git) {
+    const candidate = git[1].trim();
+    if (classifyCategoryToken(candidate) !== null) return candidate;
+  }
+
+  const linkedCommit = t.match(
+    /^\[(?:`)?[0-9a-f]{7,40}(?:`)?\]\([^)]+\)\s*:?\s*([\s\S]+)$/i,
+  );
+  if (linkedCommit) {
+    const candidate = linkedCommit[1].trim();
+    if (classifyCategoryToken(candidate) !== null) return candidate;
+  }
+
+  let prev;
+  do {
+    prev = t;
+    t = t.replace(/^\[[^\]]+\]\([^)]+\)\s+/i, "").trim();
+    if (classifyCategoryToken(t) !== null) return t;
+  } while (t !== prev);
+
+  return String(text).trim();
+}
+
+/**
+ * @param {string} text Changelog bullet text after the list marker (`- `).
+ * @returns {CategoryBucket | null}
+ */
+export function classifyChangelogBullet(text) {
+  return classifyCategoryToken(stripChangelogBulletAnnotations(text));
+}
+
+/**
+ * @param {string} text Changelog bullet text after the list marker (`- `).
+ * @returns {string}
+ */
+export function stripChangelogBulletCategoryPrefix(text) {
+  return stripCategoryPrefix(stripChangelogBulletAnnotations(text));
+}
+
+/**
  * @param {string} content Full changeset markdown file contents.
  * @returns {{ ok: true, headline: string, bucket: CategoryBucket } | { ok: false, error: string }}
  */
@@ -170,6 +229,7 @@ export function formatAcceptedPrefixesList() {
     (g) => `${g.section}: ${g.prefixes.join(", ")}`,
   ).join("; ");
 }
+
 CHIUBAKA_ORB_CATEGORY_PREFIXES_V1_EOF
 cat >"$verify_out" <<'CHIUBAKA_ORB_VERIFY_CATEGORY_PREFIXES_V1_EOF'
 #!/usr/bin/env node

--- a/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
+++ b/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
@@ -126,6 +126,65 @@ export function stripCategoryPrefix(text) {
 }
 
 /**
+ * Strip Changesets changelog bullet metadata before category matching.
+ * `@changesets/cli/changelog` re-exports `@changesets/changelog-git`, which prefixes bullets with
+ * `<shortSha>: ` when a changeset commit is known. `@changesets/changelog-github` may prefix with
+ * PR/commit links and a `Thanks …! - ` segment before the summary headline.
+ *
+ * @param {string} text Changelog bullet text after the list marker (`- `).
+ * @returns {string} Headline suitable for {@link classifyCategoryToken}.
+ */
+export function stripChangelogBulletAnnotations(text) {
+  let t = String(text).trim();
+  if (classifyCategoryToken(t) !== null) return t;
+
+  const github = t.match(/^[\s\S]+?\s+-\s+([\s\S]+)$/);
+  if (github) {
+    const candidate = github[1].trim();
+    if (classifyCategoryToken(candidate) !== null) return candidate;
+  }
+
+  const git = t.match(/^[0-9a-f]{7,40}\s*:\s*([\s\S]+)$/i);
+  if (git) {
+    const candidate = git[1].trim();
+    if (classifyCategoryToken(candidate) !== null) return candidate;
+  }
+
+  const linkedCommit = t.match(
+    /^\[(?:`)?[0-9a-f]{7,40}(?:`)?\]\([^)]+\)\s*:?\s*([\s\S]+)$/i,
+  );
+  if (linkedCommit) {
+    const candidate = linkedCommit[1].trim();
+    if (classifyCategoryToken(candidate) !== null) return candidate;
+  }
+
+  let prev;
+  do {
+    prev = t;
+    t = t.replace(/^\[[^\]]+\]\([^)]+\)\s+/i, "").trim();
+    if (classifyCategoryToken(t) !== null) return t;
+  } while (t !== prev);
+
+  return String(text).trim();
+}
+
+/**
+ * @param {string} text Changelog bullet text after the list marker (`- `).
+ * @returns {CategoryBucket | null}
+ */
+export function classifyChangelogBullet(text) {
+  return classifyCategoryToken(stripChangelogBulletAnnotations(text));
+}
+
+/**
+ * @param {string} text Changelog bullet text after the list marker (`- `).
+ * @returns {string}
+ */
+export function stripChangelogBulletCategoryPrefix(text) {
+  return stripCategoryPrefix(stripChangelogBulletAnnotations(text));
+}
+
+/**
  * @param {string} content Full changeset markdown file contents.
  * @returns {{ ok: true, headline: string, bucket: CategoryBucket } | { ok: false, error: string }}
  */
@@ -169,6 +228,7 @@ export function formatAcceptedPrefixesList() {
     (g) => `${g.section}: ${g.prefixes.join(", ")}`,
   ).join("; ");
 }
+
 CHIUBAKA_ORB_CATEGORY_PREFIXES_V1_EOF
 out=${FORMAT_CHANGESETS_BATCH_STAGE_PATH:-/tmp/chiubaka-formatChangesetsBatchReleaseNotes.mjs}
 cat >"$out" <<'CHIUBAKA_ORB_FORMATTER_V1_EOF'
@@ -218,8 +278,7 @@ const BUMP_TYPE_CONFIG = {
 };
 
 function buildCategoryConfig(prefixes) {
-  const { classifyCategoryToken, CATEGORY_ORDER, CATEGORY_SECTION_TITLE, CATEGORY_TOKEN_RE } =
-    prefixes;
+  const { classifyChangelogBullet, CATEGORY_ORDER, CATEGORY_SECTION_TITLE } = prefixes;
   return {
     order: CATEGORY_ORDER,
     titles: CATEGORY_SECTION_TITLE,
@@ -239,7 +298,7 @@ function buildCategoryConfig(prefixes) {
       const first = block[0];
       const m = String(first).match(/^[-*]\s?(.*)$/);
       const text = m ? m[1] : String(first).replace(/^[-*]\s?/, "");
-      return classifyCategoryToken(text);
+      return classifyChangelogBullet(text);
     },
   };
 }
@@ -377,7 +436,7 @@ function parseVersionBody(bodyLines, config) {
 
 function emitNestedUnderPackage(blocks, prefixes) {
   const out = [];
-  const stripFn = prefixes?.stripCategoryPrefix ?? ((t) => t);
+  const stripFn = prefixes?.stripChangelogBulletCategoryPrefix ?? ((t) => t);
   for (const block of blocks) {
     if (!block || block.length === 0) continue;
     const first = block[0];
@@ -462,6 +521,7 @@ main().catch((err) => {
   console.error(err instanceof Error ? err.message : err);
   process.exit(1);
 });
+
 CHIUBAKA_ORB_FORMATTER_V1_EOF
 rewrite_out=${REWRITE_CHANGELOG_CATEGORIES_STAGE_PATH:-/tmp/chiubaka-rewriteChangelogCategories.mjs}
 cat >"$rewrite_out" <<'CHIUBAKA_ORB_REWRITER_V1_EOF'
@@ -593,18 +653,21 @@ function collectUntilNextHeading(lines, start) {
 }
 
 function collectBlocksFromBody(bodyLines, prefixes) {
-  const { classifyCategoryToken, CATEGORY_ORDER, stripCategoryPrefix } = prefixes;
+  const { classifyChangelogBullet, CATEGORY_ORDER, stripChangelogBulletCategoryPrefix } =
+    prefixes;
   /** @type {Record<string, string[][][]>} */
   const buckets = Object.fromEntries(CATEGORY_ORDER.map((key) => [key, []]));
   const unclassified = [];
 
   function addBlocks(blocks) {
     for (const block of blocks) {
-      const bucket = classifyCategoryToken(bulletSummaryText(block));
+      const bucket = classifyChangelogBullet(bulletSummaryText(block));
       if (bucket === null) {
         unclassified.push(block);
       } else {
-        buckets[bucket].push(stripCategoryTokenFromBlock(block, stripCategoryPrefix));
+        buckets[bucket].push(
+          stripCategoryTokenFromBlock(block, stripChangelogBulletCategoryPrefix),
+        );
       }
     }
   }
@@ -694,4 +757,5 @@ main().catch((err) => {
   console.error(err instanceof Error ? err.message : err);
   process.exit(1);
 });
+
 CHIUBAKA_ORB_REWRITER_V1_EOF

--- a/test/changesetCategoryPrefixes.bats
+++ b/test/changesetCategoryPrefixes.bats
@@ -80,3 +80,38 @@ setup() {
   "
   assert_success
 }
+
+@test "classifyChangelogBullet strips changelog-git shortSha prefix" {
+  run node -e "
+    import {
+      classifyChangelogBullet,
+      stripChangelogBulletCategoryPrefix,
+    } from '$PREFIXES';
+    const text = '977f100: Feature: Show application deadlines';
+    if (classifyChangelogBullet(text) !== 'features') process.exit(1);
+    if (stripChangelogBulletCategoryPrefix(text) !== 'Show application deadlines') process.exit(2);
+  "
+  assert_success
+}
+
+@test "classifyChangelogBullet handles changelog-github metadata prefix" {
+  run node -e "
+    import {
+      classifyChangelogBullet,
+      stripChangelogBulletCategoryPrefix,
+    } from '$PREFIXES';
+    const text = '[#42](https://github.com/org/repo/pull/42) [\`977f100\`](https://github.com/org/repo/commit/977f100) Thanks [@alice](https://github.com/alice)! - Fix: Correct deadline parsing';
+    if (classifyChangelogBullet(text) !== 'bugfixes') process.exit(1);
+    if (stripChangelogBulletCategoryPrefix(text) !== 'Correct deadline parsing') process.exit(2);
+  "
+  assert_success
+}
+
+@test "classifyChangelogBullet still rejects genuinely prefix-less bullets" {
+  run node -e "
+    import { classifyChangelogBullet } from '$PREFIXES';
+    if (classifyChangelogBullet('977f100: missing prefix line') !== null) process.exit(1);
+    if (classifyChangelogBullet('plain summary') !== null) process.exit(2);
+  "
+  assert_success
+}

--- a/test/formatChangesetsBatchReleaseNotes.bats
+++ b/test/formatChangesetsBatchReleaseNotes.bats
@@ -132,6 +132,28 @@ EOF
   rm -f "$out"
 }
 
+@test "category mode accepts changelog-git shortSha prefixed bullets" {
+  local out
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  _make_pkg_changelog directus 2026.06.24.1 "### Minor Changes
+- 977f100: Feature: Show application deadlines
+- 51fd230: Improvement: Editors can control display order
+### Patch Changes
+- abcdef0: Fix: Correct deadline parsing"
+
+  out=$(mktemp)
+  run env RELEASE_NOTES_GROUPING=category node "$FORMATTER" "$out" directus/CHANGELOG.md
+  assert_success
+
+  run grep -F "### Features" "$out"
+  assert_success
+  run grep -F "Show application deadlines" "$out"
+  assert_success
+  run grep -F "977f100:" "$out"
+  assert_failure
+  rm -f "$out"
+}
+
 @test "category mode places Other-prefixed bullets under Other Changes" {
   local out
   cd "$BATS_TEST_TMPDIR" || exit 1

--- a/test/rewriteChangelogCategories.bats
+++ b/test/rewriteChangelogCategories.bats
@@ -74,6 +74,39 @@ EOF
   assert_success
 }
 
+@test "rewriter accepts default changelog-git bullets with shortSha prefix" {
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  mkdir -p pkg
+  cat >pkg/CHANGELOG.md <<'EOF'
+# @t/directus
+## 2026.06.24.1
+### Minor Changes
+- 977f100: Feature: Show application deadlines on learning opportunities
+- 51fd230: Improvement: Editors can control display order
+### Patch Changes
+- abcdef0: Fix: Correct deadline parsing
+- fedcba9: Other: Internal dependency maintenance
+EOF
+
+  run node "$REWRITER" pkg/CHANGELOG.md
+  assert_success
+
+  run grep -F "### Features" pkg/CHANGELOG.md
+  assert_success
+  run grep -F "### Improvements" pkg/CHANGELOG.md
+  assert_success
+  run grep -F "### Bug Fixes" pkg/CHANGELOG.md
+  assert_success
+  run grep -F "### Other Changes" pkg/CHANGELOG.md
+  assert_success
+  run grep -F "Show application deadlines on learning opportunities" pkg/CHANGELOG.md
+  assert_success
+  run grep -F "977f100:" pkg/CHANGELOG.md
+  assert_failure
+  run grep -F "Feature:" pkg/CHANGELOG.md
+  assert_failure
+}
+
 @test "embedded rewriter in stage script matches rewriteChangelogCategories.mjs" {
   local embedded expected
   embedded="$(python3 -c "


### PR DESCRIPTION
## Summary

- Fix `rewriteChangelogCategories` and category-mode `formatChangesetsBatchReleaseNotes` falsely flagging every bullet as missing a category prefix when Changesets emits `\<shortSha\>: \<Prefix\>: …` lines (default `@changesets/cli/changelog`, which re-exports `@changesets/changelog-git`).
- Add shared normalization in `changesetCategoryPrefixes.mjs` (`stripChangelogBulletAnnotations`, `classifyChangelogBullet`, `stripChangelogBulletCategoryPrefix`) so rewrite and batch formatting agree with verify-changesets on the headline text.
- Cover default changelog-git bullets, changelog-github metadata prefixes, and prefix-less regression cases in Bats tests; sync embedded CircleCI stage script copies.

## Test plan

- [x] `pnpm test` (146 tests, including new changelog-git/github annotation cases)
- [x] `pnpm lint`
- [ ] Consumer release PR with `release-notes-grouping: category` completes `rewriteChangelogCategories` successfully


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Changelog and release notes now correctly recognize category labels even when entries include extra Changesets/GitHub annotation text.
  * Rendered output no longer shows raw short SHA prefixes or similar metadata, resulting in cleaner release notes.
  * Category grouping is more reliable for existing changelog bullets (including Features, Improvements, Bug Fixes, and Other Changes).

* **Tests**
  * Added coverage for annotated changelog bullets, category-based release note rendering, and changelog rewriting with short-SHA-prefixed bullets.

* **Chores**
  * Updated Changesets configuration to improve changelog bullet category prefix handling with commit annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->