### PR TITLE
fix(verify-release-manifest): stage validator for CircleCI consumers

### DIFF
--- a/.changeset/fix-verify-release-manifest-staging.md
+++ b/.changeset/fix-verify-release-manifest-staging.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fix `verify-release-manifest` by staging `validateReleaseManifest.mjs` to `/tmp` before the PR check runs, matching the `verify-changesets` pattern. Repos without `.releases/` manifests now skip cleanly; repos with manifests validate via `VALIDATE_RELEASE_MANIFEST_SCRIPT`.

--- a/.changeset/fix-verify-release-manifest-staging.md
+++ b/.changeset/fix-verify-release-manifest-staging.md
@@ -2,4 +2,4 @@
 "@chiubaka/circleci-orb": patch
 ---
 
-Fix `verify-release-manifest` by staging `validateReleaseManifest.mjs` to `/tmp` before the PR check runs, matching the `verify-changesets` pattern. Repos without `.releases/` manifests now skip cleanly; repos with manifests validate via `VALIDATE_RELEASE_MANIFEST_SCRIPT`.
+Fix: Stage `validateReleaseManifest.mjs` for `verify-release-manifest` in CircleCI consumers so sibling `.mjs` files are not required on disk. Repos without `.releases/` manifests skip cleanly; repos with manifests validate via `VALIDATE_RELEASE_MANIFEST_SCRIPT`.

--- a/src/commands/verify-release-manifest.yml
+++ b/src/commands/verify-release-manifest.yml
@@ -18,8 +18,13 @@ parameters:
 
 steps:
   - run:
+      name: Stage release manifest validator
+      working_directory: << parameters.app-dir >>
+      command: << include(scripts/stageReleaseManifestValidator.sh) >>
+  - run:
       name: Verify release manifests (ADR 0038)
       working_directory: << parameters.app-dir >>
       command: << include(scripts/runVerifyReleaseManifest.sh) >>
       environment:
         VERIFY_RELEASE_MANIFEST_MODE: << parameters.verify-mode >>
+        VALIDATE_RELEASE_MANIFEST_SCRIPT: /tmp/chiubaka-validateReleaseManifest.mjs

--- a/src/scripts/runVerifyReleaseManifest.sh
+++ b/src/scripts/runVerifyReleaseManifest.sh
@@ -15,22 +15,35 @@ list_manifest_paths() {
   } | grep -E '^\.releases/[^/]+\.yml$' | LC_ALL=C sort -u || true
 }
 
+_resolve_validator_script() {
+  if [[ -n "${VALIDATE_RELEASE_MANIFEST_SCRIPT:-}" && -f "${VALIDATE_RELEASE_MANIFEST_SCRIPT}" ]]; then
+    printf '%s\n' "$VALIDATE_RELEASE_MANIFEST_SCRIPT"
+    return 0
+  fi
+  local sibling
+  # shellcheck disable=SC3028
+  sibling="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/validateReleaseManifest.mjs"
+  if [[ -f "$sibling" ]]; then
+    printf '%s\n' "$sibling"
+    return 0
+  fi
+  echo "runVerifyReleaseManifest: set VALIDATE_RELEASE_MANIFEST_SCRIPT or keep validateReleaseManifest.mjs next to this script." >&2
+  return 1
+}
+
 run_verify_release_manifest_main() {
   local app_dir validator paths path n=0
   app_dir=${APP_DIR:-.}
   cd "$app_dir"
 
-  # shellcheck disable=SC3028
-  validator="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)/validateReleaseManifest.mjs"
-  if [[ ! -f "$validator" ]]; then
-    echo "runVerifyReleaseManifest: validateReleaseManifest.mjs not found." >&2
-    exit 1
-  fi
-
   mapfile -t paths < <(list_manifest_paths | grep -v '^$' || true)
   if [[ ${#paths[@]} -eq 0 ]]; then
     echo "runVerifyReleaseManifest: no .releases/*.yml to validate; skipping."
     exit 0
+  fi
+
+  if ! validator=$(_resolve_validator_script); then
+    exit 1
   fi
 
   for path in "${paths[@]}"; do

--- a/src/scripts/stageReleaseManifestValidator.sh
+++ b/src/scripts/stageReleaseManifestValidator.sh
@@ -1,0 +1,148 @@
+#! /usr/bin/env bash
+# Materialize release manifest validator for CircleCI consumers (orb packs this script;
+# sibling .mjs files are not on disk in the client repo). Keep heredoc body in sync with
+# validateReleaseManifest.mjs.
+set -euo pipefail
+validator_out=${VALIDATE_RELEASE_MANIFEST_STAGE_PATH:-/tmp/chiubaka-validateReleaseManifest.mjs}
+cat >"$validator_out" <<'CHIUBAKA_ORB_VALIDATE_RELEASE_MANIFEST_V1_EOF'
+#!/usr/bin/env node
+/**
+ * Strict pin-only release manifest validation (ADR 0038).
+ * Usage: node validateReleaseManifest.mjs <path-to-manifest.yml>
+ * Exports RELEASE_MANIFEST_PATH, RELEASE_ID, ARTIFACTS_JSON on success (stdout).
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+const RELEASE_ID_RE = /^[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]+$/;
+const ALLOWED_TOP_KEYS = new Set(["release", "artifacts"]);
+
+function fail(msg) {
+  process.stderr.write(`validateReleaseManifest: ${msg}\n`);
+  process.exit(1);
+}
+
+function parsePinOnlyYaml(text, filePath) {
+  const lines = text.split(/\r?\n/);
+  let release;
+  const artifacts = {};
+  let inArtifacts = false;
+  const seenTop = new Set();
+
+  for (let i = 0; i < lines.length; i++) {
+    const raw = lines[i];
+    const line = raw.replace(/\s+#.*$/, "").trimEnd();
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+
+    if (/^\S/.test(line) && !line.startsWith("artifacts:")) {
+      const m = line.match(/^([a-zA-Z0-9_-]+):\s*(.*)$/);
+      if (!m) fail(`${filePath}:${i + 1}: expected top-level key: value`);
+      const key = m[1];
+      const value = m[2].trim();
+      if (!ALLOWED_TOP_KEYS.has(key)) {
+        fail(
+          `${filePath}:${i + 1}: unknown top-level key "${key}" (pin-only manifests allow only release and artifacts; see ADR 0038)`,
+        );
+      }
+      if (seenTop.has(key)) {
+        fail(`${filePath}:${i + 1}: duplicate top-level key "${key}"`);
+      }
+      seenTop.add(key);
+      if (key === "release") {
+        release = unquoteYamlScalar(value);
+        inArtifacts = false;
+      } else if (key === "artifacts") {
+        inArtifacts = true;
+        if (value) fail(`${filePath}:${i + 1}: artifacts must be a mapping, not inline value`);
+      }
+      continue;
+    }
+
+    if (line.startsWith("artifacts:")) {
+      inArtifacts = true;
+      seenTop.add("artifacts");
+      continue;
+    }
+
+    if (inArtifacts) {
+      const m = line.match(/^\s{2,}([a-zA-Z0-9_-]+):\s*(.+)$/);
+      if (!m) {
+        fail(`${filePath}:${i + 1}: expected artifact key under artifacts:`);
+      }
+      const artKey = m[1];
+      const artVal = unquoteYamlScalar(m[2].trim());
+      if (Object.prototype.hasOwnProperty.call(artifacts, artKey)) {
+        fail(`${filePath}:${i + 1}: duplicate artifact key "${artKey}"`);
+      }
+      artifacts[artKey] = artVal;
+    } else {
+      fail(`${filePath}:${i + 1}: unexpected indented line outside artifacts`);
+    }
+  }
+
+  return { release, artifacts };
+}
+
+function unquoteYamlScalar(value) {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function validateManifestFile(filePath) {
+  const abs = path.resolve(filePath);
+  if (!fs.existsSync(abs)) {
+    fail(`file not found: ${filePath}`);
+  }
+  const base = path.basename(abs, path.extname(abs));
+  const text = fs.readFileSync(abs, "utf8");
+  if (/^deploy\s*:/m.test(text)) {
+    fail(
+      `${abs}: pin-only manifests must not include a top-level deploy key (ADR 0038); ordering belongs in repo deploy tooling`,
+    );
+  }
+  const doc = parsePinOnlyYaml(text, abs);
+
+  if (!doc.release) {
+    fail(`${abs}: missing required field "release"`);
+  }
+  if (!RELEASE_ID_RE.test(doc.release)) {
+    fail(
+      `${abs}: release must match YYYY.MM.DD.N (got "${doc.release}"); see ADR 0031`,
+    );
+  }
+  if (base !== doc.release) {
+    fail(
+      `${abs}: filename stem "${base}" must match release field "${doc.release}"`,
+    );
+  }
+  if (!doc.artifacts || Object.keys(doc.artifacts).length === 0) {
+    fail(`${abs}: artifacts mapping must be present and non-empty`);
+  }
+  for (const [key, val] of Object.entries(doc.artifacts)) {
+    if (!key.trim()) fail(`${abs}: empty artifact key`);
+    if (!val || typeof val !== "string" || !val.trim()) {
+      fail(`${abs}: artifact "${key}" must be a non-empty string tag`);
+    }
+  }
+
+  return { release: doc.release, artifacts: doc.artifacts, path: abs };
+}
+
+function main() {
+  const filePath = process.argv[2] ?? process.env.RELEASE_MANIFEST_PATH;
+  if (!filePath) {
+    fail("usage: validateReleaseManifest.mjs <path-to-manifest.yml>");
+  }
+  const result = validateManifestFile(filePath);
+  process.stdout.write(`RELEASE_MANIFEST_PATH=${result.path}\n`);
+  process.stdout.write(`RELEASE_ID=${result.release}\n`);
+  process.stdout.write(`ARTIFACTS_JSON=${JSON.stringify(result.artifacts)}\n`);
+}
+
+main();
+CHIUBAKA_ORB_VALIDATE_RELEASE_MANIFEST_V1_EOF

--- a/test/runVerifyReleaseManifest.bats
+++ b/test/runVerifyReleaseManifest.bats
@@ -1,0 +1,141 @@
+#! /usr/bin/env bats
+
+setup() {
+  load "helpers/setup"
+  _setup
+}
+
+_simulate_circleci_script() {
+  local dest_dir=$1
+  mkdir -p "$dest_dir"
+  cp "$PROJECT_ROOT/src/scripts/runVerifyReleaseManifest.sh" "$dest_dir/runVerifyReleaseManifest.sh"
+}
+
+@test "skips when no manifests without requiring staged validator" {
+  repo_dir="${BATS_TEST_TMPDIR}/repo-no-manifests"
+  script_dir="${BATS_TEST_TMPDIR}/circleci-script"
+  mkdir -p "${repo_dir}"
+  _simulate_circleci_script "${script_dir}"
+
+  cd "${repo_dir}"
+  git init -b master >/dev/null
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  printf "readme\n" > README.md
+  git add README.md
+  git commit -m "base" >/dev/null
+
+  run bash "${script_dir}/runVerifyReleaseManifest.sh"
+
+  assert_success
+  assert_output --partial "no .releases/*.yml to validate; skipping."
+}
+
+@test "fails when manifests exist but validator is not staged" {
+  repo_dir="${BATS_TEST_TMPDIR}/repo-with-manifest"
+  script_dir="${BATS_TEST_TMPDIR}/circleci-script-missing-validator"
+  mkdir -p "${repo_dir}/.releases"
+  _simulate_circleci_script "${script_dir}"
+  cp "$PROJECT_ROOT/test/fixtures/release-manifests/2026.05.08.1.yml" \
+    "${repo_dir}/.releases/2026.05.08.1.yml"
+
+  cd "${repo_dir}"
+  git init -b master >/dev/null
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+
+  VERIFY_RELEASE_MANIFEST_MODE=all \
+    run bash "${script_dir}/runVerifyReleaseManifest.sh"
+
+  assert_failure
+  assert_output --partial "set VALIDATE_RELEASE_MANIFEST_SCRIPT"
+}
+
+@test "validates manifests via staged validator override in all mode" {
+  repo_dir="${BATS_TEST_TMPDIR}/repo-staged-validator"
+  script_dir="${BATS_TEST_TMPDIR}/circleci-script-staged"
+  staged_validator="${BATS_TEST_TMPDIR}/chiubaka-validateReleaseManifest.mjs"
+  mkdir -p "${repo_dir}/.releases"
+  _simulate_circleci_script "${script_dir}"
+  VALIDATE_RELEASE_MANIFEST_STAGE_PATH="${staged_validator}" \
+    bash "$PROJECT_ROOT/src/scripts/stageReleaseManifestValidator.sh"
+  cp "$PROJECT_ROOT/test/fixtures/release-manifests/2026.05.08.1.yml" \
+    "${repo_dir}/.releases/2026.05.08.1.yml"
+
+  cd "${repo_dir}"
+  git init -b master >/dev/null
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+
+  VERIFY_RELEASE_MANIFEST_MODE=all \
+  VALIDATE_RELEASE_MANIFEST_SCRIPT="${staged_validator}" \
+    run bash "${script_dir}/runVerifyReleaseManifest.sh"
+
+  assert_success
+  assert_output --partial "validated 1 manifest(s)."
+}
+
+@test "validates untracked manifests in changed mode via staged validator override" {
+  repo_dir="${BATS_TEST_TMPDIR}/repo-changed-mode"
+  script_dir="${BATS_TEST_TMPDIR}/circleci-script-changed"
+  staged_validator="${BATS_TEST_TMPDIR}/chiubaka-validateReleaseManifest-changed.mjs"
+  mkdir -p "${repo_dir}/.releases"
+  _simulate_circleci_script "${script_dir}"
+  VALIDATE_RELEASE_MANIFEST_STAGE_PATH="${staged_validator}" \
+    bash "$PROJECT_ROOT/src/scripts/stageReleaseManifestValidator.sh"
+  cp "$PROJECT_ROOT/test/fixtures/release-manifests/2026.05.08.1.yml" \
+    "${repo_dir}/.releases/2026.05.08.1.yml"
+
+  cd "${repo_dir}"
+  git init -b master >/dev/null
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  printf "readme\n" > README.md
+  git add README.md
+  git commit -m "base" >/dev/null
+
+  VALIDATE_RELEASE_MANIFEST_SCRIPT="${staged_validator}" \
+    run bash "${script_dir}/runVerifyReleaseManifest.sh"
+
+  assert_success
+  assert_output --partial "validated 1 manifest(s)."
+}
+
+@test "fails on invalid manifest via staged validator override" {
+  repo_dir="${BATS_TEST_TMPDIR}/repo-invalid-manifest"
+  script_dir="${BATS_TEST_TMPDIR}/circleci-script-invalid"
+  staged_validator="${BATS_TEST_TMPDIR}/chiubaka-validateReleaseManifest-invalid.mjs"
+  mkdir -p "${repo_dir}/.releases"
+  _simulate_circleci_script "${script_dir}"
+  VALIDATE_RELEASE_MANIFEST_STAGE_PATH="${staged_validator}" \
+    bash "$PROJECT_ROOT/src/scripts/stageReleaseManifestValidator.sh"
+  cp "$PROJECT_ROOT/test/fixtures/release-manifests/invalid-deploy-key.yml" \
+    "${repo_dir}/.releases/invalid-deploy-key.yml"
+
+  cd "${repo_dir}"
+  git init -b master >/dev/null
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+
+  VERIFY_RELEASE_MANIFEST_MODE=all \
+  VALIDATE_RELEASE_MANIFEST_SCRIPT="${staged_validator}" \
+    run bash "${script_dir}/runVerifyReleaseManifest.sh"
+
+  assert_failure
+  assert_output --partial "deploy"
+}
+
+@test "embedded release manifest validator matches source module" {
+  local embedded expected
+  embedded="$(python3 -c "
+from pathlib import Path
+import sys
+t = Path(sys.argv[1]).read_text()
+start_m = \"<<'CHIUBAKA_ORB_VALIDATE_RELEASE_MANIFEST_V1_EOF'\\n\"
+i = t.index(start_m) + len(start_m)
+end = t.index('\\nCHIUBAKA_ORB_VALIDATE_RELEASE_MANIFEST_V1_EOF', i)
+sys.stdout.write(t[i : end + 1])
+" "$PROJECT_ROOT/src/scripts/stageReleaseManifestValidator.sh")"
+  expected="$(cat "$PROJECT_ROOT/src/scripts/validateReleaseManifest.mjs")"
+  assert_equal "$expected" "$embedded"
+}


### PR DESCRIPTION
## Summary

- **Valid bug:** `verify-release-manifest` failed on every PR because `<< include() >>` inlines only `runVerifyReleaseManifest.sh`; the sibling `validateReleaseManifest.mjs` is never on disk in consumer repos, so validator resolution always failed before the no-manifest skip path.
- **Fix:** Mirror the existing `verify-changesets` pattern — add `stageReleaseManifestValidator.sh` to heredoc the self-contained validator to `/tmp/chiubaka-validateReleaseManifest.mjs`, wire `VALIDATE_RELEASE_MANIFEST_SCRIPT` in the command, and teach `runVerifyReleaseManifest.sh` to honor that override (with sibling fallback for local/dev use).
- **Hardening:** Reorder `runVerifyReleaseManifest.sh` so repos without `.releases/*.yml` skip cleanly (exit 0) even when the validator is not staged.

## Test plan

- [x] `pnpm test` — new `test/runVerifyReleaseManifest.bats` covers CircleCI-style script isolation, staged validator override, `all` and `changed` modes, invalid manifest failure, and heredoc sync with source `.mjs`
- [x] `pnpm lint`
- [ ] After orb publish: confirm `verify-release-manifest` passes on a PR with no `.releases/` directory
- [ ] After orb publish: confirm it validates a valid `.releases/<id>.yml` and fails on schema violations


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `verify-release-manifest` reliability in staging/CI, including repositories with no release manifests.
  * Verification now prefers a staged validator script when available, with a safe fallback if not.
  * Stricter manifest validation and clearer failure reporting (including duplicate keys/artifact tags and invalid format).
* **Tests**
  * Added end-to-end Bats coverage for manifest verification across absent/present manifests, validator override behavior, and validation failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->