### PR TITLE
fix(release-notes): trust category headings after changelog rewrite

### DIFF
--- a/.changeset/fix-formatter-post-rewrite-changelog.md
+++ b/.changeset/fix-formatter-post-rewrite-changelog.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fix: Trust category section headings in batch release note formatting when `rewriteChangelogCategories` has already stripped prefix tokens from changelog bullets.

--- a/src/scripts/formatChangesetsBatchReleaseNotes.mjs
+++ b/src/scripts/formatChangesetsBatchReleaseNotes.mjs
@@ -159,11 +159,9 @@ function parseVersionBody(bodyLines, config) {
           buckets[cat].push(b);
         } else {
           const bucket = config.classifyBulletBlock(b);
-          if (bucket === null) {
-            unclassified.push(b);
-          } else {
-            buckets[bucket].push(b);
-          }
+          // rewriteChangelogCategories strips prefix tokens after placing bullets under category
+          // headings; trust the section when the headline no longer carries a prefix token.
+          buckets[bucket ?? cat].push(b);
         }
       }
     } else {

--- a/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
+++ b/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
@@ -393,11 +393,9 @@ function parseVersionBody(bodyLines, config) {
           buckets[cat].push(b);
         } else {
           const bucket = config.classifyBulletBlock(b);
-          if (bucket === null) {
-            unclassified.push(b);
-          } else {
-            buckets[bucket].push(b);
-          }
+          // rewriteChangelogCategories strips prefix tokens after placing bullets under category
+          // headings; trust the section when the headline no longer carries a prefix token.
+          buckets[bucket ?? cat].push(b);
         }
       }
     } else {

--- a/test/formatChangesetsBatchReleaseNotes.bats
+++ b/test/formatChangesetsBatchReleaseNotes.bats
@@ -132,6 +132,30 @@ EOF
   rm -f "$out"
 }
 
+@test "category mode accepts bullets under category headings after rewriteChangelogCategories" {
+  local out
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  _make_pkg_changelog app 1.0.0 "### Features
+- Add optional include-pr-metadata for PR continuation parameters.
+### Bug Fixes
+- Recognize category prefixes on changelog bullets that include Changesets commit annotations.
+- Stage validateReleaseManifest.mjs for verify-release-manifest in CircleCI consumers."
+
+  out=$(mktemp)
+  run env RELEASE_NOTES_GROUPING=category node "$FORMATTER" "$out" app/CHANGELOG.md
+  assert_success
+
+  run grep -F "### Features" "$out"
+  assert_success
+  run grep -F "### Bug Fixes" "$out"
+  assert_success
+  run grep -F "include-pr-metadata" "$out"
+  assert_success
+  run grep -F "validateReleaseManifest.mjs" "$out"
+  assert_success
+  rm -f "$out"
+}
+
 @test "category mode accepts changelog-git shortSha prefixed bullets" {
   local out
   cd "$BATS_TEST_TMPDIR" || exit 1


### PR DESCRIPTION
## Summary
- Fix release PR failure when formatChangesetsBatchReleaseNotes runs after rewriteChangelogCategories has stripped category prefix tokens from changelog bullets
- Fall back to the category section heading when a bullet under that heading no longer carries a prefix token
- Add regression test and changeset

## Test plan
- [x] bats test/formatChangesetsBatchReleaseNotes.bats
- [x] bats test/formatChangesetsBatchReleaseNotesEmbedding.bats
- [x] Full pnpm test suite (158 tests)
- [x] End-to-end: changeset version → rewriteChangelogCategories → formatChangesetsBatchReleaseNotes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release note formatting so category-based changelog entries no longer fail when bullet prefixes have already been removed.
  * Ensured bullets are grouped under the correct category heading during batch release note generation.
* **Tests**
  * Added coverage for category-grouped release notes to confirm expected content is preserved in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->