### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.20.0)

### DIFF
--- a/.changeset/compute-changesets-pr-metadata.md
+++ b/.changeset/compute-changesets-pr-metadata.md
@@ -1,7 +1,0 @@
----
-"@chiubaka/circleci-orb": minor
----
-
-Feature: Add optional `include-pr-metadata` for PR continuation parameters.
-
-CircleCI setup workflows do not propagate `CIRCLE_PULL_REQUEST` / `CIRCLE_PR_NUMBER` into continuation pipelines; opt in when downstream jobs (for example Codecov PR association) need that context.

--- a/.changeset/fix-changelog-category-prefix-annotations.md
+++ b/.changeset/fix-changelog-category-prefix-annotations.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: Recognize category prefixes on changelog bullets that include Changesets commit annotations (`<shortSha>:` prefixes).

--- a/.changeset/fix-formatter-post-rewrite-changelog.md
+++ b/.changeset/fix-formatter-post-rewrite-changelog.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: Trust category section headings in batch release note formatting when `rewriteChangelogCategories` has already stripped prefix tokens from changelog bullets.

--- a/.changeset/fix-verify-release-manifest-staging.md
+++ b/.changeset/fix-verify-release-manifest-staging.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: Stage `validateReleaseManifest.mjs` for `verify-release-manifest` in CircleCI consumers so sibling `.mjs` files are not required on disk. Repos without `.releases/` manifests skip cleanly; repos with manifests validate via `VALIDATE_RELEASE_MANIFEST_SCRIPT`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @chiubaka/circleci-orb
 
+## 0.20.0
+### Features
+
+- Add optional `include-pr-metadata` for PR continuation parameters.
+
+  CircleCI setup workflows do not propagate `CIRCLE_PULL_REQUEST` / `CIRCLE_PR_NUMBER` into continuation pipelines; opt in when downstream jobs (for example Codecov PR association) need that context.
+
+### Bug Fixes
+
+- Recognize category prefixes on changelog bullets that include Changesets commit annotations (`<shortSha>:` prefixes).
+- Trust category section headings in batch release note formatting when `rewriteChangelogCategories` has already stripped prefix tokens from changelog bullets.
+- Stage `validateReleaseManifest.mjs` for `verify-release-manifest` in CircleCI consumers so sibling `.mjs` files are not required on disk. Repos without `.releases/` manifests skip cleanly; repos with manifests validate via `VALIDATE_RELEASE_MANIFEST_SCRIPT`.
 ## 0.19.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### Features

- **@chiubaka/circleci-orb**
  - Add optional `include-pr-metadata` for PR continuation parameters.

      CircleCI setup workflows do not propagate `CIRCLE_PULL_REQUEST` / `CIRCLE_PR_NUMBER` into continuation pipelines; opt in when downstream jobs (for example Codecov PR association) need that context.

### Bug Fixes

- **@chiubaka/circleci-orb**
  - Recognize category prefixes on changelog bullets that include Changesets commit annotations (`<shortSha>:` prefixes).
  - Trust category section headings in batch release note formatting when `rewriteChangelogCategories` has already stripped prefix tokens from changelog bullets.
  - Stage `validateReleaseManifest.mjs` for `verify-release-manifest` in CircleCI consumers so sibling `.mjs` files are not required on disk. Repos without `.releases/` manifests skip cleanly; repos with manifests validate via `VALIDATE_RELEASE_MANIFEST_SCRIPT`.

## Published versions

- `@chiubaka/circleci-orb@0.20.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional PR metadata support for CircleCI continuation flows, helping preserve pull request context in pipelines.

- **Bug Fixes**
  - Improved changelog formatting so category headings and annotated entries are recognized more reliably.
  - Made release verification work more smoothly in projects without release manifests, reducing unnecessary file requirements.

- **Chores**
  - Bumped the package version to **0.20.0**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->