### PR TITLE
fix(changesets): emit markdownlint-compliant changelog heading spacing

### DIFF
--- a/.changeset/changelog-md022-spacing.md
+++ b/.changeset/changelog-md022-spacing.md
@@ -1,0 +1,7 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fix: Emit markdownlint-compliant blank lines around changelog headings after category rewrite.
+
+`rewriteChangelogCategories` now joins rewritten version blocks with blank lines before and after `##` and `###` headings so generated `CHANGELOG.md` files pass `markdown/blanks-around-headings` (MD022) under `@chiubaka/eslint-config`.

--- a/src/scripts/rewriteChangelogCategories.mjs
+++ b/src/scripts/rewriteChangelogCategories.mjs
@@ -188,6 +188,16 @@ function renderCategoryBody(buckets, prefixes) {
   return out.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
 }
 
+function joinChangelogSections(...sections) {
+  return (
+    sections
+      .filter((section) => section !== "")
+      .join("\n\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trimEnd() + "\n"
+  );
+}
+
 function rewriteChangelogFile(absPath, prefixes) {
   const raw = fs.readFileSync(absPath, "utf8");
   const section = extractTopVersionSection(raw);
@@ -199,11 +209,8 @@ function rewriteChangelogFile(absPath, prefixes) {
   const newBody = renderCategoryBody(buckets, prefixes);
   const before = section.lines.slice(0, section.bodyStart).join("\n");
   const after = section.lines.slice(section.bodyEnd).join("\n");
-  const parts = [before];
-  if (newBody) parts.push(newBody);
-  if (after) parts.push(after);
-  const text = parts.filter((p, idx) => p !== "" || idx === 0).join("\n");
-  fs.writeFileSync(absPath, text.endsWith("\n") ? text : `${text}\n`, "utf8");
+  const text = joinChangelogSections(before, newBody, after);
+  fs.writeFileSync(absPath, text, "utf8");
   return true;
 }
 

--- a/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
+++ b/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
@@ -713,6 +713,16 @@ function renderCategoryBody(buckets, prefixes) {
   return out.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd();
 }
 
+function joinChangelogSections(...sections) {
+  return (
+    sections
+      .filter((section) => section !== "")
+      .join("\n\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trimEnd() + "\n"
+  );
+}
+
 function rewriteChangelogFile(absPath, prefixes) {
   const raw = fs.readFileSync(absPath, "utf8");
   const section = extractTopVersionSection(raw);
@@ -724,11 +734,8 @@ function rewriteChangelogFile(absPath, prefixes) {
   const newBody = renderCategoryBody(buckets, prefixes);
   const before = section.lines.slice(0, section.bodyStart).join("\n");
   const after = section.lines.slice(section.bodyEnd).join("\n");
-  const parts = [before];
-  if (newBody) parts.push(newBody);
-  if (after) parts.push(after);
-  const text = parts.filter((p, idx) => p !== "" || idx === 0).join("\n");
-  fs.writeFileSync(absPath, text.endsWith("\n") ? text : `${text}\n`, "utf8");
+  const text = joinChangelogSections(before, newBody, after);
+  fs.writeFileSync(absPath, text, "utf8");
   return true;
 }
 

--- a/test/rewriteChangelogCategories.bats
+++ b/test/rewriteChangelogCategories.bats
@@ -107,6 +107,46 @@ EOF
   assert_failure
 }
 
+@test "rewriter emits markdownlint MD022 blanks around headings" {
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  mkdir -p pkg
+  cat >pkg/CHANGELOG.md <<'EOF'
+# @t/pkg
+
+## 2.0.0
+### Patch Changes
+- Fix: Correct spacing
+
+## 1.0.0
+
+### Patch Changes
+
+- Fix: Older release
+EOF
+
+  run node "$REWRITER" pkg/CHANGELOG.md
+  assert_success
+
+  run python3 - "$BATS_TEST_TMPDIR/pkg/CHANGELOG.md" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+lines = open(path, encoding="utf-8").read().splitlines()
+heading = re.compile(r"^#{1,6}\s")
+for index, line in enumerate(lines):
+    if not heading.match(line):
+        continue
+    if index > 0 and lines[index - 1].strip() != "":
+        print(f"missing blank before heading at line {index + 1}: {line!r}", file=sys.stderr)
+        sys.exit(1)
+    if index + 1 < len(lines) and lines[index + 1].strip() != "":
+        print(f"missing blank after heading at line {index + 1}: {line!r}", file=sys.stderr)
+        sys.exit(1)
+PY
+  assert_success
+}
+
 @test "embedded rewriter in stage script matches rewriteChangelogCategories.mjs" {
   local embedded expected
   embedded="$(python3 -c "


### PR DESCRIPTION
## Summary
- Fix `rewriteChangelogCategories` section joining so rewritten `CHANGELOG.md` files include blank lines before and after `##` / `###` headings (markdownlint MD022 / `markdown/blanks-around-headings`).
- Keep the embedded rewriter in `stageFormatChangesetsBatchReleaseNotes.sh` in sync with the source module.
- Add a Bats regression test that asserts MD022 spacing after category rewrite.

## Test plan
- [x] `pnpm exec bats test/rewriteChangelogCategories.bats`
- [x] `pnpm lint`
- [x] `pnpm test`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed changelog rewriting so generated `CHANGELOG.md` files keep proper blank lines around headings, avoiding markdown lint issues.
  * Improved how rewritten changelog sections are combined, preventing extra blank lines and ensuring a clean trailing newline.
* **Tests**
  * Added coverage to verify rewritten changelog output preserves valid spacing around all headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->