### PR TITLE
feat(orb): add mint-github-token for GitHub App installation tokens

### DIFF
--- a/.changeset/mint-github-token.md
+++ b/.changeset/mint-github-token.md
@@ -1,0 +1,7 @@
+---
+"@chiubaka/circleci-orb": minor
+---
+
+Add mint-github-token command to export GITHUB_TOKEN from a GitHub App or an existing PAT.
+
+When `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, and `GITHUB_APP_INSTALLATION_ID` are set, mints a short-lived installation access token and exports it as `GITHUB_TOKEN` and `GH_TOKEN` (including via `BASH_ENV` for later steps). When those app variables are unset and `GITHUB_TOKEN` is already provided, passes it through unchanged.

--- a/.changeset/mint-github-token.md
+++ b/.changeset/mint-github-token.md
@@ -2,6 +2,6 @@
 "@chiubaka/circleci-orb": minor
 ---
 
-Add mint-github-token command to export GITHUB_TOKEN from a GitHub App or an existing PAT.
+Feature: Add mint-github-token command to export GITHUB_TOKEN from a GitHub App or an existing PAT.
 
 When `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, and `GITHUB_APP_INSTALLATION_ID` are set, mints a short-lived installation access token and exports it as `GITHUB_TOKEN` and `GH_TOKEN` (including via `BASH_ENV` for later steps). When those app variables are unset and `GITHUB_TOKEN` is already provided, passes it through unchanged.

--- a/src/commands/changesets-release-pr.yml
+++ b/src/commands/changesets-release-pr.yml
@@ -3,7 +3,7 @@ description: >
   release/<primary-branch>, push, and open or update one GitHub PR into the default branch via gh.
   If changeset version does not change any package.json (e.g. empty or verification-only changesets),
   exits successfully without opening a PR. Requires GITHUB_TOKEN (contents, pull requests; push to
-  release/*). Install gh first (see job) or use an image that includes gh.
+  release/*) or mint one first with mint-github-token from a client-owned GitHub App. Install gh first (see job) or use an image that includes gh.
 
 parameters:
   app-dir:

--- a/src/commands/mint-github-token.yml
+++ b/src/commands/mint-github-token.yml
@@ -1,0 +1,23 @@
+description: >
+  Export GITHUB_TOKEN (and GH_TOKEN) for downstream orb steps. When GITHUB_APP_ID,
+  GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_INSTALLATION_ID are set in the environment,
+  mints a short-lived GitHub App installation access token. When none of those are set
+  but GITHUB_TOKEN is already provided (for example from a CircleCI context PAT), uses
+  that value unchanged. Appends exports to BASH_ENV when present so later steps in the
+  same job inherit the token. Run before changesets-release-pr, github-release-train,
+  push-promotion-tag, or setup-npm-registry-auth when using a client-owned GitHub App.
+
+parameters:
+  github-api-url:
+    type: string
+    default: "https://api.github.com"
+    description: >
+      GitHub REST API base URL. Override for GitHub Enterprise Server; github.com
+      installations use the default.
+
+steps:
+  - run:
+      name: Mint or resolve GitHub token
+      command: << include(scripts/mintGithubToken.sh) >>
+      environment:
+        GITHUB_API_URL: << parameters.github-api-url >>

--- a/src/examples/mint-github-token-github-app.yml
+++ b/src/examples/mint-github-token-github-app.yml
@@ -1,0 +1,23 @@
+description: >
+  Mint a GitHub App installation token in CI before release automation. Store
+  GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_INSTALLATION_ID in a CircleCI
+  context (client-owned app). For PAT-based auth instead, provide GITHUB_TOKEN in the
+  context and omit the app variables.
+
+usage:
+  version: 2.1
+  orbs:
+    chiubaka: chiubaka/circleci-orb@0.20.1
+
+  workflows:
+    release-pr:
+      jobs:
+        - chiubaka/changesets-release-pr:
+            context:
+              - github-release-app
+            pre-steps:
+              - chiubaka/mint-github-token
+            primary-branch: main
+            filters:
+              branches:
+                only: main

--- a/src/examples/mint-github-token-github-app.yml
+++ b/src/examples/mint-github-token-github-app.yml
@@ -1,13 +1,14 @@
 description: >
-  Mint a GitHub App installation token in CI before release automation. Store
-  GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_INSTALLATION_ID in a CircleCI
-  context (client-owned app). For PAT-based auth instead, provide GITHUB_TOKEN in the
+  Mint a GitHub App installation token in CI before release automation. Requires
+  chiubaka/circleci-orb@0.21.0 or newer (mint-github-token). Store GITHUB_APP_ID,
+  GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_INSTALLATION_ID in a CircleCI context
+  (client-owned app). For PAT-based auth instead, provide GITHUB_TOKEN in the
   context and omit the app variables.
 
 usage:
   version: 2.1
   orbs:
-    chiubaka: chiubaka/circleci-orb@0.20.1
+    chiubaka: chiubaka/circleci-orb@0.21.0
 
   workflows:
     release-pr:

--- a/src/scripts/mintGithubToken.sh
+++ b/src/scripts/mintGithubToken.sh
@@ -1,0 +1,132 @@
+#! /usr/bin/env bash
+# Resolve GITHUB_TOKEN for downstream orb steps: mint a GitHub App installation token
+# when GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_INSTALLATION_ID are set;
+# otherwise use GITHUB_TOKEN when provided directly.
+set -euo pipefail
+
+github_api_url=${GITHUB_API_URL:-https://api.github.com}
+
+base64url_encode() {
+  openssl base64 -e -A | tr '+/' '-_' | tr -d $'\n=' 
+}
+
+normalize_app_private_key() {
+  local raw=$1
+  if [[ "$raw" == *'-----BEGIN'* ]]; then
+    if [[ "$raw" == *'\\n'* ]]; then
+      printf '%b' "$raw"
+    else
+      printf '%s' "$raw"
+    fi
+    return 0
+  fi
+  printf '%s' "$raw" | base64 -d
+}
+
+count_set_github_app_credentials() {
+  local count=0
+  [[ -n "${GITHUB_APP_ID:-}" ]] && count=$((count + 1))
+  [[ -n "${GITHUB_APP_PRIVATE_KEY:-}" ]] && count=$((count + 1))
+  [[ -n "${GITHUB_APP_INSTALLATION_ID:-}" ]] && count=$((count + 1))
+  printf '%s' "$count"
+}
+
+build_github_app_jwt() {
+  local app_id=$1
+  local private_key_pem=$2
+  local key_file now issued_at expires_at header payload unsigned signature
+
+  now=$(date +%s)
+  issued_at=$((now - 60))
+  expires_at=$((now + 540))
+
+  header='{"alg":"RS256","typ":"JWT"}'
+  payload=$(printf '{"iat":%s,"exp":%s,"iss":"%s"}' "$issued_at" "$expires_at" "$app_id")
+
+  header_b64=$(printf '%s' "$header" | base64url_encode)
+  payload_b64=$(printf '%s' "$payload" | base64url_encode)
+  unsigned="${header_b64}.${payload_b64}"
+
+  key_file=$(mktemp)
+  normalize_app_private_key "$private_key_pem" >"$key_file"
+  signature=$(printf '%s' "$unsigned" | openssl dgst -sha256 -sign "$key_file" -binary | base64url_encode)
+  rm -f "$key_file"
+  printf '%s.%s' "$unsigned" "$signature"
+}
+
+mint_github_app_installation_token() {
+  local app_id=$1
+  local private_key_pem=$2
+  local installation_id=$3
+  local jwt response token
+
+  jwt=$(build_github_app_jwt "$app_id" "$private_key_pem")
+  response=$(
+    curl -fsS -X POST \
+      -H "Authorization: Bearer ${jwt}" \
+      -H "Accept: application/vnd.github+json" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "${github_api_url%/}/app/installations/${installation_id}/access_tokens"
+  )
+  token=$(printf '%s' "$response" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')
+  if [[ -z "$token" ]]; then
+    echo "mintGithubToken: GitHub API returned an empty installation token." >&2
+    exit 1
+  fi
+  printf '%s' "$token"
+}
+
+export_github_token() {
+  local token=$1
+  export GITHUB_TOKEN="$token"
+  export GH_TOKEN="$token"
+  if [[ -n "${BASH_ENV:-}" ]]; then
+    {
+      printf 'export GITHUB_TOKEN=%q\n' "$token"
+      printf 'export GH_TOKEN=%q\n' "$token"
+    } >>"$BASH_ENV"
+  fi
+}
+
+resolve_github_token() {
+  local app_credentials_set=${1:-0}
+
+  if [[ "$app_credentials_set" -eq 3 ]]; then
+    mint_github_app_installation_token \
+      "$GITHUB_APP_ID" \
+      "$GITHUB_APP_PRIVATE_KEY" \
+      "$GITHUB_APP_INSTALLATION_ID"
+    return 0
+  fi
+
+  if [[ "$app_credentials_set" -ne 0 ]]; then
+    echo "mintGithubToken: set all of GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_INSTALLATION_ID together, or none of them." >&2
+    exit 1
+  fi
+
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    printf '%s' "$GITHUB_TOKEN"
+    return 0
+  fi
+
+  echo "mintGithubToken: set GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY, and GITHUB_APP_INSTALLATION_ID to mint a token, or set GITHUB_TOKEN directly." >&2
+  exit 1
+}
+
+mint_github_token_main() {
+  local token app_credentials_set
+
+  app_credentials_set=$(count_set_github_app_credentials)
+  token=$(resolve_github_token "$app_credentials_set")
+  export_github_token "$token"
+
+  if [[ "$app_credentials_set" -eq 3 ]]; then
+    echo "mintGithubToken: exported minted GitHub App installation token as GITHUB_TOKEN."
+  else
+    echo "mintGithubToken: exported provided GITHUB_TOKEN."
+  fi
+}
+
+if [[ "${MINT_GITHUB_TOKEN_SOURCE_ONLY:-}" != "true" ]]; then
+  mint_github_token_main "$@"
+fi

--- a/src/scripts/mintGithubToken.sh
+++ b/src/scripts/mintGithubToken.sh
@@ -47,11 +47,23 @@ build_github_app_jwt() {
   payload_b64=$(printf '%s' "$payload" | base64url_encode)
   unsigned="${header_b64}.${payload_b64}"
 
-  key_file=$(mktemp)
-  normalize_app_private_key "$private_key_pem" >"$key_file"
-  signature=$(printf '%s' "$unsigned" | openssl dgst -sha256 -sign "$key_file" -binary | base64url_encode)
-  rm -f "$key_file"
+  signature=$(
+    key_file=$(mktemp)
+    trap 'rm -f "$key_file"' EXIT
+    normalize_app_private_key "$private_key_pem" >"$key_file"
+    printf '%s' "$unsigned" | openssl dgst -sha256 -sign "$key_file" -binary | base64url_encode
+  )
   printf '%s.%s' "$unsigned" "$signature"
+}
+
+parse_installation_token_from_response() {
+  local response=$1
+  if [[ "$response" =~ \"token\"[[:space:]]*:[[:space:]]*\"([^\"]+)\" ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+  echo "mintGithubToken: GitHub API response did not include an installation token." >&2
+  return 1
 }
 
 mint_github_app_installation_token() {
@@ -68,7 +80,7 @@ mint_github_app_installation_token() {
       -H "X-GitHub-Api-Version: 2022-11-28" \
       "${github_api_url%/}/app/installations/${installation_id}/access_tokens"
   )
-  token=$(printf '%s' "$response" | python3 -c 'import json,sys; print(json.load(sys.stdin)["token"])')
+  token=$(parse_installation_token_from_response "$response") || exit 1
   if [[ -z "$token" ]]; then
     echo "mintGithubToken: GitHub API returned an empty installation token." >&2
     exit 1

--- a/test/mintGithubToken.bats
+++ b/test/mintGithubToken.bats
@@ -17,6 +17,7 @@ setup() {
     count_set_github_app_credentials \
     build_github_app_jwt \
     mint_github_app_installation_token \
+    parse_installation_token_from_response \
     export_github_token \
     resolve_github_token
 
@@ -33,6 +34,18 @@ teardown() {
     unset BASH_ENV
   fi
   unset _ORIGINAL_BASH_ENV
+}
+
+@test "parse_installation_token_from_response extracts token from GitHub JSON" {
+  run parse_installation_token_from_response '{"token":"ghs_minted_test_token","expires_at":"2099-01-01T00:00:00Z"}'
+  assert_success
+  assert_output "ghs_minted_test_token"
+}
+
+@test "parse_installation_token_from_response fails when token is missing" {
+  run parse_installation_token_from_response '{"expires_at":"2099-01-01T00:00:00Z"}'
+  assert_failure
+  assert_output --partial "did not include an installation token"
 }
 
 @test "resolve_github_token returns provided GITHUB_TOKEN when app credentials are unset" {

--- a/test/mintGithubToken.bats
+++ b/test/mintGithubToken.bats
@@ -3,6 +3,11 @@ setup() {
   load "helpers/setup"
   _setup
   unset GITHUB_TOKEN GH_TOKEN GITHUB_APP_ID GITHUB_APP_PRIVATE_KEY GITHUB_APP_INSTALLATION_ID
+  # CircleCI sets BASH_ENV globally; export_github_token appends token exports there.
+  # Isolate it so later bats files are not polluted when bash sources BASH_ENV.
+  _ORIGINAL_BASH_ENV="${BASH_ENV:-}"
+  BASH_ENV="${BATS_TEST_TMPDIR}/mint_github_token_bash_env"
+  : >"$BASH_ENV"
   MINT_GITHUB_TOKEN_SOURCE_ONLY=true
   # shellcheck disable=SC1091
   source "$PROJECT_ROOT/src/scripts/mintGithubToken.sh"
@@ -22,6 +27,12 @@ setup() {
 
 teardown() {
   unset GITHUB_TOKEN GH_TOKEN GITHUB_APP_ID GITHUB_APP_PRIVATE_KEY GITHUB_APP_INSTALLATION_ID
+  if [[ -n "${_ORIGINAL_BASH_ENV:-}" ]]; then
+    BASH_ENV="$_ORIGINAL_BASH_ENV"
+  else
+    unset BASH_ENV
+  fi
+  unset _ORIGINAL_BASH_ENV
 }
 
 @test "resolve_github_token returns provided GITHUB_TOKEN when app credentials are unset" {

--- a/test/mintGithubToken.bats
+++ b/test/mintGithubToken.bats
@@ -1,0 +1,116 @@
+# shellcheck disable=SC2030,SC2031
+setup() {
+  load "helpers/setup"
+  _setup
+  unset GITHUB_TOKEN GH_TOKEN GITHUB_APP_ID GITHUB_APP_PRIVATE_KEY GITHUB_APP_INSTALLATION_ID
+  MINT_GITHUB_TOKEN_SOURCE_ONLY=true
+  # shellcheck disable=SC1091
+  source "$PROJECT_ROOT/src/scripts/mintGithubToken.sh"
+  export -f \
+    base64url_encode \
+    normalize_app_private_key \
+    count_set_github_app_credentials \
+    build_github_app_jwt \
+    mint_github_app_installation_token \
+    export_github_token \
+    resolve_github_token
+
+  TEST_APP_PRIVATE_KEY=$(
+    openssl genrsa 2048 2>/dev/null
+  )
+}
+
+teardown() {
+  unset GITHUB_TOKEN GH_TOKEN GITHUB_APP_ID GITHUB_APP_PRIVATE_KEY GITHUB_APP_INSTALLATION_ID
+}
+
+@test "resolve_github_token returns provided GITHUB_TOKEN when app credentials are unset" {
+  GITHUB_TOKEN=ghp_direct
+  run resolve_github_token 0
+  assert_success
+  assert_output "ghp_direct"
+}
+
+@test "resolve_github_token fails when no credentials are configured" {
+  run resolve_github_token 0
+  assert_failure
+  assert_output --partial "set GITHUB_APP_ID"
+}
+
+@test "resolve_github_token fails when app credentials are partial" {
+  GITHUB_APP_ID=12345
+  run resolve_github_token 1
+  assert_failure
+  assert_output --partial "set all of GITHUB_APP_ID"
+}
+
+@test "build_github_app_jwt produces a three-part RS256 token" {
+  jwt=$(build_github_app_jwt "12345" "$TEST_APP_PRIVATE_KEY")
+  [[ "$jwt" == *.*.* ]] || false
+  IFS=. read -r header payload signature <<<"$jwt"
+  [[ -n "$header" && -n "$payload" && -n "$signature" ]] || false
+}
+
+@test "normalize_app_private_key decodes base64-encoded PEM" {
+  encoded=$(printf '%s' "$TEST_APP_PRIVATE_KEY" | base64 -w0 2>/dev/null || printf '%s' "$TEST_APP_PRIVATE_KEY" | base64)
+  normalized=$(normalize_app_private_key "$encoded")
+  [[ "$normalized" == *"BEGIN RSA PRIVATE KEY"* ]] || [[ "$normalized" == *"BEGIN PRIVATE KEY"* ]] || false
+}
+
+_run_mint_github_token_main() {
+  # Orb steps inline this script; source it in tests so exports match CircleCI behavior.
+  # shellcheck disable=SC1091
+  source "$PROJECT_ROOT/src/scripts/mintGithubToken.sh"
+  mint_github_token_main "$@"
+}
+
+@test "mint_github_token_main exports provided GITHUB_TOKEN" {
+  GITHUB_TOKEN=ghp_direct
+  _run_mint_github_token_main >/dev/null
+  assert_equal "ghp_direct" "$GITHUB_TOKEN"
+  assert_equal "ghp_direct" "$GH_TOKEN"
+}
+
+@test "mint_github_token_main writes provided GITHUB_TOKEN to BASH_ENV" {
+  bash_env="${BATS_TEST_TMPDIR}/bash_env"
+  : >"$bash_env"
+  GITHUB_TOKEN=ghp_direct BASH_ENV="$bash_env" _run_mint_github_token_main >/dev/null
+  run grep 'GITHUB_TOKEN=ghp_direct' "$bash_env"
+  assert_success
+  run grep 'GH_TOKEN=ghp_direct' "$bash_env"
+  assert_success
+}
+
+@test "resolve_github_token prefers app credentials over an existing GITHUB_TOKEN" {
+  GITHUB_TOKEN=ghp_direct
+  GITHUB_APP_ID=12345
+  GITHUB_APP_PRIVATE_KEY="$TEST_APP_PRIVATE_KEY"
+  GITHUB_APP_INSTALLATION_ID=98765
+
+  local curl_mock bindir
+  curl_mock="$(mock_create)"
+  mock_set_output "${curl_mock}" '{"token":"ghs_minted_test_token","expires_at":"2099-01-01T00:00:00Z"}'
+  bindir=$(mktemp -d)
+  ln -sf "$curl_mock" "${bindir}/curl"
+
+  PATH="${bindir}:$PATH" run resolve_github_token 3
+  assert_success
+  assert_output "ghs_minted_test_token"
+}
+
+@test "mint_github_token_main mints installation token from app credentials" {
+  curl_mock="$(mock_create)"
+  mock_set_output "${curl_mock}" '{"token":"ghs_minted_test_token","expires_at":"2099-01-01T00:00:00Z"}'
+  bindir=$(mktemp -d)
+  ln -sf "$curl_mock" "${bindir}/curl"
+
+  GITHUB_APP_ID=12345
+  GITHUB_APP_PRIVATE_KEY="$TEST_APP_PRIVATE_KEY"
+  GITHUB_APP_INSTALLATION_ID=98765
+  PATH="${bindir}:$PATH" _run_mint_github_token_main >/dev/null
+
+  assert_equal "ghs_minted_test_token" "$GITHUB_TOKEN"
+  args=$(mock_get_call_args "$curl_mock" 1)
+  [[ "$args" == *"/app/installations/98765/access_tokens"* ]] || false
+  [[ "$args" == *"Authorization: Bearer "* ]] || false
+}


### PR DESCRIPTION
## Summary
- Add `mint-github-token` command and `mintGithubToken.sh` to export `GITHUB_TOKEN` / `GH_TOKEN` for downstream orb steps.
- When `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, and `GITHUB_APP_INSTALLATION_ID` are all set, mint a short-lived GitHub App installation access token via the REST API.
- When those app variables are unset and `GITHUB_TOKEN` is already provided (for example from a CircleCI context PAT), pass it through unchanged.
- Writes exports to `BASH_ENV` when present so later steps in the same job inherit the token.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (includes 9 new `mintGithubToken.bats` cases)
- [ ] Client smoke: run `mint-github-token` as a workflow `pre-step` before `changesets-release-pr` with a client-owned GitHub App context


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable CircleCI command to mint or resolve GitHub tokens for downstream steps, preferring a short-lived GitHub App installation token when app credentials are set.
  * Added an example CircleCI configuration demonstrating the token-minting step in release automation.
* **Documentation**
  * Clarified the `changesets-release-pr` workflow description around required token permissions when pending changesets exist.
* **Release**
  * Added a Changesets entry for a minor bump.
* **Tests**
  * Added Bats tests covering token resolution, JWT building/normalization, and exporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->