### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.21.0)

### DIFF
--- a/.changeset/changelog-md022-spacing.md
+++ b/.changeset/changelog-md022-spacing.md
@@ -1,7 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: Emit markdownlint-compliant blank lines around changelog headings after category rewrite.
-
-`rewriteChangelogCategories` now joins rewritten version blocks with blank lines before and after `##` and `###` headings so generated `CHANGELOG.md` files pass `markdown/blanks-around-headings` (MD022) under `@chiubaka/eslint-config`.

--- a/.changeset/mint-github-token.md
+++ b/.changeset/mint-github-token.md
@@ -1,7 +1,0 @@
----
-"@chiubaka/circleci-orb": minor
----
-
-Feature: Add mint-github-token command to export GITHUB_TOKEN from a GitHub App or an existing PAT.
-
-When `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, and `GITHUB_APP_INSTALLATION_ID` are set, mints a short-lived installation access token and exports it as `GITHUB_TOKEN` and `GH_TOKEN` (including via `BASH_ENV` for later steps). When those app variables are unset and `GITHUB_TOKEN` is already provided, passes it through unchanged.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,21 @@
 # @chiubaka/circleci-orb
 
+## 0.21.0
+
+### Features
+
+- Add mint-github-token command to export GITHUB_TOKEN from a GitHub App or an existing PAT.
+
+  When `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, and `GITHUB_APP_INSTALLATION_ID` are set, mints a short-lived installation access token and exports it as `GITHUB_TOKEN` and `GH_TOKEN` (including via `BASH_ENV` for later steps). When those app variables are unset and `GITHUB_TOKEN` is already provided, passes it through unchanged.
+
+### Bug Fixes
+
+- Emit markdownlint-compliant blank lines around changelog headings after category rewrite.
+
+  `rewriteChangelogCategories` now joins rewritten version blocks with blank lines before and after `##` and `###` headings so generated `CHANGELOG.md` files pass `markdown/blanks-around-headings` (MD022) under `@chiubaka/eslint-config`.
+
 ## 0.20.1
+
 ### Bug Fixes
 
 - Stage lib/trainId.sh for github-release-train and unblock push-promotion-tag in CircleCI consumers.
@@ -10,6 +25,7 @@
 - Stage writeReleaseManifest.mjs for changesets-release-pr when create-release-manifest is enabled.
 
   CircleCI consumers no longer fail with "writeReleaseManifest.mjs not found" because the orb materializes the manifest writer to /tmp and sets WRITE_RELEASE_MANIFEST_SCRIPT, matching the verify-release-manifest staging pattern.
+
 ## 0.20.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### Features

- **@chiubaka/circleci-orb**
  - Add mint-github-token command to export GITHUB_TOKEN from a GitHub App or an existing PAT.

      When `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, and `GITHUB_APP_INSTALLATION_ID` are set, mints a short-lived installation access token and exports it as `GITHUB_TOKEN` and `GH_TOKEN` (including via `BASH_ENV` for later steps). When those app variables are unset and `GITHUB_TOKEN` is already provided, passes it through unchanged.

### Bug Fixes

- **@chiubaka/circleci-orb**
  - Emit markdownlint-compliant blank lines around changelog headings after category rewrite.

      `rewriteChangelogCategories` now joins rewritten version blocks with blank lines before and after `##` and `###` headings so generated `CHANGELOG.md` files pass `markdown/blanks-around-headings` (MD022) under `@chiubaka/eslint-config`.

## Published versions

- `@chiubaka/circleci-orb@0.21.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command that exports a short-lived GitHub token for use as `GITHUB_TOKEN` or `GH_TOKEN`, while preserving any existing token.
* **Bug Fixes**
  * Improved generated changelog formatting so rewritten section headings include the correct spacing and comply with markdown linting rules.
* **Chores**
  * Updated the project version to `0.21.0` and added the latest release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->