### PR TITLE
fix(changesets): allow empty changesets through category-prefix verification

### DIFF
--- a/.changeset/allow-empty-changeset-prefix-validation.md
+++ b/.changeset/allow-empty-changeset-prefix-validation.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fix: Skip category-prefix validation for empty changesets created with `changeset add --empty`.

--- a/src/scripts/changesetCategoryPrefixes.mjs
+++ b/src/scripts/changesetCategoryPrefixes.mjs
@@ -178,10 +178,36 @@ export function stripChangelogBulletCategoryPrefix(text) {
 }
 
 /**
+ * YAML between the opening `---` delimiters of a Changesets file (package bump declarations).
+ * @param {string} content
+ * @returns {string | null} Null when frontmatter delimiters are missing.
+ */
+export function extractChangesetFrontmatterYaml(content) {
+  const normalized = String(content).replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---")) return null;
+  const close = normalized.indexOf("\n---", 3);
+  if (close === -1) return null;
+  return normalized.slice(3, close).trim();
+}
+
+/**
+ * True when a changeset deliberately releases no packages (`changeset add --empty`).
+ * @param {string} content
+ * @returns {boolean}
+ */
+export function isEmptyChangeset(content) {
+  const yaml = extractChangesetFrontmatterYaml(content);
+  return yaml !== null && yaml === "";
+}
+
+/**
  * @param {string} content Full changeset markdown file contents.
- * @returns {{ ok: true, headline: string, bucket: CategoryBucket } | { ok: false, error: string }}
+ * @returns {{ ok: true, empty: true } | { ok: true, headline: string, bucket: CategoryBucket } | { ok: false, error: string }}
  */
 export function validateChangesetSummaryCategory(content) {
+  if (isEmptyChangeset(content)) {
+    return { ok: true, empty: true };
+  }
   const headline = extractChangesetSummaryHeadline(content);
   if (headline === null) {
     return { ok: false, error: "changeset has no summary headline after frontmatter" };

--- a/src/scripts/stageChangesetCategoryPrefixScripts.sh
+++ b/src/scripts/stageChangesetCategoryPrefixScripts.sh
@@ -186,10 +186,36 @@ export function stripChangelogBulletCategoryPrefix(text) {
 }
 
 /**
+ * YAML between the opening `---` delimiters of a Changesets file (package bump declarations).
+ * @param {string} content
+ * @returns {string | null} Null when frontmatter delimiters are missing.
+ */
+export function extractChangesetFrontmatterYaml(content) {
+  const normalized = String(content).replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---")) return null;
+  const close = normalized.indexOf("\n---", 3);
+  if (close === -1) return null;
+  return normalized.slice(3, close).trim();
+}
+
+/**
+ * True when a changeset deliberately releases no packages (`changeset add --empty`).
+ * @param {string} content
+ * @returns {boolean}
+ */
+export function isEmptyChangeset(content) {
+  const yaml = extractChangesetFrontmatterYaml(content);
+  return yaml !== null && yaml === "";
+}
+
+/**
  * @param {string} content Full changeset markdown file contents.
- * @returns {{ ok: true, headline: string, bucket: CategoryBucket } | { ok: false, error: string }}
+ * @returns {{ ok: true, empty: true } | { ok: true, headline: string, bucket: CategoryBucket } | { ok: false, error: string }}
  */
 export function validateChangesetSummaryCategory(content) {
+  if (isEmptyChangeset(content)) {
+    return { ok: true, empty: true };
+  }
   const headline = extractChangesetSummaryHeadline(content);
   if (headline === null) {
     return { ok: false, error: "changeset has no summary headline after frontmatter" };

--- a/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
+++ b/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
@@ -185,10 +185,36 @@ export function stripChangelogBulletCategoryPrefix(text) {
 }
 
 /**
+ * YAML between the opening `---` delimiters of a Changesets file (package bump declarations).
+ * @param {string} content
+ * @returns {string | null} Null when frontmatter delimiters are missing.
+ */
+export function extractChangesetFrontmatterYaml(content) {
+  const normalized = String(content).replace(/\r\n/g, "\n");
+  if (!normalized.startsWith("---")) return null;
+  const close = normalized.indexOf("\n---", 3);
+  if (close === -1) return null;
+  return normalized.slice(3, close).trim();
+}
+
+/**
+ * True when a changeset deliberately releases no packages (`changeset add --empty`).
+ * @param {string} content
+ * @returns {boolean}
+ */
+export function isEmptyChangeset(content) {
+  const yaml = extractChangesetFrontmatterYaml(content);
+  return yaml !== null && yaml === "";
+}
+
+/**
  * @param {string} content Full changeset markdown file contents.
- * @returns {{ ok: true, headline: string, bucket: CategoryBucket } | { ok: false, error: string }}
+ * @returns {{ ok: true, empty: true } | { ok: true, headline: string, bucket: CategoryBucket } | { ok: false, error: string }}
  */
 export function validateChangesetSummaryCategory(content) {
+  if (isEmptyChangeset(content)) {
+    return { ok: true, empty: true };
+  }
   const headline = extractChangesetSummaryHeadline(content);
   if (headline === null) {
     return { ok: false, error: "changeset has no summary headline after frontmatter" };

--- a/test/changesetCategoryPrefixes.bats
+++ b/test/changesetCategoryPrefixes.bats
@@ -81,6 +81,28 @@ setup() {
   assert_success
 }
 
+@test "isEmptyChangeset recognizes changeset add --empty format" {
+  run node -e "
+    import { isEmptyChangeset, validateChangesetSummaryCategory } from '$PREFIXES';
+    const content = '---\\n---\\n';
+    if (!isEmptyChangeset(content)) process.exit(1);
+    const r = validateChangesetSummaryCategory(content);
+    if (!r.ok || !r.empty) process.exit(2);
+  "
+  assert_success
+}
+
+@test "validateChangesetSummaryCategory still rejects non-empty changeset without headline" {
+  run node -e "
+    import { validateChangesetSummaryCategory } from '$PREFIXES';
+    const content = '---\\n\"@t/pkg\": patch\\n---\\n';
+    const r = validateChangesetSummaryCategory(content);
+    if (r.ok) process.exit(1);
+    if (!r.error.includes('no summary headline')) process.exit(2);
+  "
+  assert_success
+}
+
 @test "classifyChangelogBullet strips changelog-git shortSha prefix" {
   run node -e "
     import {

--- a/test/runVerifyChangesets.bats
+++ b/test/runVerifyChangesets.bats
@@ -281,3 +281,39 @@ EOF
   assert_equal "$(mock_get_call_num "${mock}")" 1
   assert_equal "$(mock_get_call_args "${mock}")" "exec changeset status"
 }
+
+@test "require-changeset-category-prefix passes empty changeset from changeset add --empty" {
+  repo_dir="${BATS_TEST_TMPDIR}/repo-empty-changeset"
+  mkdir -p "${repo_dir}/.changeset"
+  cd "${repo_dir}"
+  git init -b master >/dev/null
+  git config user.email "test@example.com"
+  git config user.name "Test User"
+  cat >.changeset/base.md <<'EOF'
+---
+"@t/pkg": patch
+---
+Feature: base
+EOF
+  git add .changeset/base.md
+  git commit -m "base" >/dev/null
+  git checkout -b feature >/dev/null
+  cat >.changeset/no-release.md <<'EOF'
+---
+---
+EOF
+  git add .changeset/no-release.md
+  git commit -m "add empty changeset" >/dev/null
+
+  mock=$(mock_create)
+
+  PNPM_BINARY="${mock}" \
+  VERIFY_SCRIPT='' \
+  PRIMARY_BRANCH=master \
+  REQUIRE_CHANGESET_CATEGORY_PREFIX=true \
+  run runVerifyChangesets.sh
+
+  assert_success
+  assert_equal "$(mock_get_call_num "${mock}")" 1
+  assert_equal "$(mock_get_call_args "${mock}")" "exec changeset status"
+}

--- a/test/verifyChangesetCategoryPrefixes.bats
+++ b/test/verifyChangesetCategoryPrefixes.bats
@@ -38,6 +38,18 @@ EOF
   assert_success
 }
 
+@test "verifyChangesetCategoryPrefixes passes empty changeset from changeset add --empty" {
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  mkdir -p .changeset
+  cat >.changeset/empty.md <<'EOF'
+---
+---
+EOF
+
+  run node "$VERIFY" .changeset/empty.md
+  assert_success
+}
+
 @test "verifyChangesetCategoryPrefixes fails on missing prefix" {
   cd "$BATS_TEST_TMPDIR" || exit 1
   mkdir -p .changeset


### PR DESCRIPTION
## Summary

- Detect `changeset add --empty` files (frontmatter with no package bumps) via new `isEmptyChangeset()` helper in `changesetCategoryPrefixes.mjs`.
- Skip category-prefix validation for empty changesets so CI can still require a `.changeset/*.md` touch without forcing a user-facing changelog line.
- Sync embedded prefix modules in `stageChangesetCategoryPrefixScripts.sh` and `stageFormatChangesetsBatchReleaseNotes.sh`, and add unit/integration bats coverage.

## Test plan

- [x] `pnpm test` (181 tests pass, including new empty-changeset cases)
- [x] `verifyChangesetCategoryPrefixes` accepts `---\n---\n`
- [x] `runVerifyChangesets.sh` with `REQUIRE_CHANGESET_CATEGORY_PREFIX=true` passes when branch adds an empty changeset


Made with [Cursor](https://cursor.com)