### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.22.0)

### DIFF
--- a/.changeset/allow-empty-changeset-prefix-validation.md
+++ b/.changeset/allow-empty-changeset-prefix-validation.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: Skip category-prefix validation for empty changesets created with `changeset add --empty`.

--- a/.changeset/release-cycle-rc-workflow.md
+++ b/.changeset/release-cycle-rc-workflow.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": minor
----
-
-Breaking: Replace flat `.releases/<id>.yml` manifests with ADR 0042 release cycle directories, per-RC notes, staging `staging-<cycle-id>-rc<n>` promotion tags, and `promote-prod-release` for production GitHub Releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @chiubaka/circleci-orb
 
+## 0.22.0
+
+### Breaking Changes
+
+- Replace flat `.releases/<id>.yml` manifests with ADR 0042 release cycle directories, per-RC notes, staging `staging-<cycle-id>-rc<n>` promotion tags, and `promote-prod-release` for production GitHub Releases.
+
+### Bug Fixes
+
+- Skip category-prefix validation for empty changesets created with `changeset add --empty`.
+
 ## 0.21.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### Breaking Changes

- **@chiubaka/circleci-orb**
  - Replace flat `.releases/<id>.yml` manifests with ADR 0042 release cycle directories, per-RC notes, staging `staging-<cycle-id>-rc<n>` promotion tags, and `promote-prod-release` for production GitHub Releases.

### Bug Fixes

- **@chiubaka/circleci-orb**
  - Skip category-prefix validation for empty changesets created with `changeset add --empty`.

## Published versions

- `@chiubaka/circleci-orb@0.22.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty changesets created with `changeset add --empty` now skip category-prefix validation, preventing a validation issue in that workflow.
* **Chores**
  * Updated the package version to `0.22.0`.
  * Added the `0.22.0` release entry to the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->