### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.22.1)

### DIFF
--- a/.changeset/fix-release-cycle-staging-inlined-orb.md
+++ b/.changeset/fix-release-cycle-staging-inlined-orb.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: Materialize release-cycle scripts via embedded heredocs in `stageReleaseCycleWriter.sh` so CircleCI consumers no longer fail with `cp: cannot stat '/bin/lib/releaseCycle.mjs'` when orb commands inline the staging step. Stage manifest validator scripts for `coordinated-deploy` and inline promotion-tag parsing so commit-primary deploy workflows work without sibling files on disk.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chiubaka/circleci-orb
 
+## 0.22.1
+
+### Bug Fixes
+
+- Materialize release-cycle scripts via embedded heredocs in `stageReleaseCycleWriter.sh` so CircleCI consumers no longer fail with `cp: cannot stat '/bin/lib/releaseCycle.mjs'` when orb commands inline the staging step. Stage manifest validator scripts for `coordinated-deploy` and inline promotion-tag parsing so commit-primary deploy workflows work without sibling files on disk.
+
 ## 0.22.0
 
 ### Breaking Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.22.0",
+  "version": "0.22.1",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### Bug Fixes

- **@chiubaka/circleci-orb**
  - Materialize release-cycle scripts via embedded heredocs in `stageReleaseCycleWriter.sh` so CircleCI consumers no longer fail with `cp: cannot stat '/bin/lib/releaseCycle.mjs'` when orb commands inline the staging step. Stage manifest validator scripts for `coordinated-deploy` and inline promotion-tag parsing so commit-primary deploy workflows work without sibling files on disk.

## Published versions

- `@chiubaka/circleci-orb@0.22.1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release-cycle staging so required scripts are included reliably during inlined orb builds, reducing missing-file errors.
  * Added support for more robust staging and inline parsing in commit-primary deploy workflows.
* **Chores**
  * Bumped the package version to `0.22.1`.
  * Updated the changelog with the latest patch release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->