### PR TITLE
fix(release): add tag-target validated mode for promote-prod-release

### DIFF
--- a/.changeset/promote-prod-tag-target-validated.md
+++ b/.changeset/promote-prod-tag-target-validated.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": minor
+---
+
+Feature: add `tag-target` parameter to `promote-prod-release` so `prod-<cycle-id>` and the GitHub Release can target the pre-finalize validated commit while finalize artifacts still land on the primary branch.

--- a/src/commands/promote-prod-release.yml
+++ b/src/commands/promote-prod-release.yml
@@ -30,6 +30,16 @@ parameters:
     type: string
     default: "<< pipeline.git.revision >>"
     description: Commit to finalize and tag (defaults to pipeline revision).
+  tag-target:
+    type: enum
+    enum:
+      - finalize
+      - validated
+    default: finalize
+    description: >
+      Which commit prod-<cycle-id> and the GitHub Release target. finalize (default) tags
+      the finalize commit on primary-branch. validated tags the pre-finalize target-ref
+      commit so deploy pins (e.g. sha-${CIRCLE_SHA1}) match the soaked RC build.
 
 steps:
   - install-github-cli
@@ -48,6 +58,7 @@ steps:
         ON_EXISTING_TAG: << parameters.on-existing-tag >>
         RELEASE_ID: << parameters.release-id >>
         TARGET_REF: << parameters.target-ref >>
+        TAG_TARGET: << parameters.tag-target >>
         FINALIZE_RELEASE_CYCLE_SCRIPT: /tmp/chiubaka-release-cycle/finalizeReleaseCycle.mjs
         RESOLVE_RELEASE_CYCLE_SCRIPT: /tmp/chiubaka-release-cycle/resolveReleaseCycleOnCommit.mjs
         ROLLUP_RELEASE_NOTES_SCRIPT: /tmp/chiubaka-release-cycle/rollupReleaseNotes.mjs

--- a/src/jobs/promote-prod-release.yml
+++ b/src/jobs/promote-prod-release.yml
@@ -29,6 +29,15 @@ parameters:
     type: string
     default: "<< pipeline.git.revision >>"
     description: Commit to finalize and tag (defaults to pipeline revision).
+  tag-target:
+    type: enum
+    enum:
+      - finalize
+      - validated
+    default: finalize
+    description: >
+      Which commit prod-<cycle-id> and the GitHub Release target. finalize tags the
+      finalize commit; validated tags the pre-finalize target-ref commit (ADR 0031).
   resource-class:
     default: medium
     enum:
@@ -53,3 +62,4 @@ steps:
       on-existing-tag: << parameters.on-existing-tag >>
       release-id: << parameters.release-id >>
       target-ref: << parameters.target-ref >>
+      tag-target: << parameters.tag-target >>

--- a/src/scripts/runPromoteProdRelease.sh
+++ b/src/scripts/runPromoteProdRelease.sh
@@ -50,9 +50,24 @@ read_cycle_from_commit() {
   CYCLE_ID=$cycle_id
 }
 
+_resolve_tag_sha() {
+  local tag_target validated_sha finalize_sha
+  tag_target=$(printf '%s' "${TAG_TARGET:-finalize}" | tr '[:upper:]' '[:lower:]')
+  validated_sha=$1
+  finalize_sha=$2
+  case "$tag_target" in
+    finalize) printf '%s\n' "$finalize_sha" ;;
+    validated) printf '%s\n' "$validated_sha" ;;
+    *)
+      echo "runPromoteProdRelease: TAG_TARGET must be finalize or validated (got ${TAG_TARGET})." >&2
+      return 1
+      ;;
+  esac
+}
+
 run_promote_prod_release_main() {
   local app_dir releases_dir cycle_dir finalize_script notes_path primary auth_header push_url repo_slug u r
-  local target_ref target_sha tag remote_sha on_existing
+  local target_ref validated_sha finalize_sha tag_sha tag remote_sha on_existing
 
   app_dir=${APP_DIR:-.}
   releases_dir=${RELEASES_DIR:-.releases}
@@ -74,8 +89,9 @@ run_promote_prod_release_main() {
   if [[ -z "$target_ref" ]]; then
     target_ref=HEAD
   fi
-  target_sha=$(git rev-parse "${target_ref}^{commit}")
-  export TARGET_SHA="$target_sha"
+  validated_sha=$(git rev-parse "${target_ref}^{commit}")
+  finalize_sha=$validated_sha
+  export TARGET_SHA="$validated_sha"
 
   if ! read_cycle_from_commit; then
     echo "runPromoteProdRelease: could not determine cycle id on ${target_ref}." >&2
@@ -105,7 +121,11 @@ run_promote_prod_release_main() {
     echo "runPromoteProdRelease: cycle already finalized on ${target_ref}; continuing."
   else
     git commit --no-verify -m "chore(release): finalize ${CYCLE_ID} for production"
-    target_sha=$(git rev-parse HEAD)
+    finalize_sha=$(git rev-parse HEAD)
+  fi
+
+  if ! tag_sha=$(_resolve_tag_sha "$validated_sha" "$finalize_sha"); then
+    exit 1
   fi
 
   repo_slug=${GITHUB_REPO_SLUG:-}
@@ -133,22 +153,22 @@ run_promote_prod_release_main() {
     remote_sha=$(git ls-remote origin "refs/tags/${tag}" | awk '{print $1}' | head -1 || true)
   fi
   if [[ -n "$remote_sha" ]]; then
-    if [[ "$remote_sha" == "$target_sha" ]]; then
+    if [[ "$remote_sha" == "$tag_sha" ]]; then
       if [[ "$on_existing" == "skip" ]]; then
-        echo "runPromoteProdRelease: tag ${tag} already exists at ${target_sha}; skipping tag push."
+        echo "runPromoteProdRelease: tag ${tag} already exists at ${tag_sha}; skipping tag push."
       else
         echo "runPromoteProdRelease: tag ${tag} already exists at target (on-existing-tag=fail)." >&2
         exit 1
       fi
     else
-      echo "runPromoteProdRelease: tag ${tag} exists on origin at ${remote_sha}, not ${target_sha}." >&2
+      echo "runPromoteProdRelease: tag ${tag} exists on origin at ${remote_sha}, not ${tag_sha}." >&2
       exit 1
     fi
   else
-    git -c tag.gpgSign=false tag -fa "$tag" -m "promotion: ${tag}" "$target_sha"
+    git -c tag.gpgSign=false tag -fa "$tag" -m "promotion: ${tag}" "$tag_sha"
     git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
       push "$push_url" "refs/tags/${tag}"
-    echo "runPromoteProdRelease: pushed ${tag} at ${target_sha}."
+    echo "runPromoteProdRelease: pushed ${tag} at ${tag_sha}."
   fi
 
   create_raw=${CREATE_GITHUB_RELEASE:-true}
@@ -168,7 +188,7 @@ run_promote_prod_release_main() {
     exit 0
   fi
 
-  gh release create "$tag" --repo "$repo_slug" --target "$target_sha" \
+  gh release create "$tag" --repo "$repo_slug" --target "$tag_sha" \
     --title "$CYCLE_ID" --notes-file "$notes_path"
   echo "runPromoteProdRelease: created GitHub Release ${tag}."
 }

--- a/test/runPromoteProdRelease.bats
+++ b/test/runPromoteProdRelease.bats
@@ -45,14 +45,9 @@ EOF
   printf '%s' "$bindir"
 }
 
-@test "default finalize mode tags prod release at finalize commit" {
-  local clone bindir gh_call_log validated_sha finalize_sha tag_sha args
-  clone=$(_promote_prod_init_clone)
-  bindir=$(_write_gh_stub)
-  gh_call_log=$(mktemp)
-  validated_sha=$(git -C "$clone" rev-parse HEAD)
-  cd "$clone" || exit 1
-
+_run_promote_prod_release() {
+  local bindir=$1 gh_call_log=$2
+  shift 2
   run env GITHUB_TOKEN=fake \
     GITHUB_REPO_SLUG=example/test \
     PRIMARY_BRANCH=master \
@@ -62,7 +57,19 @@ EOF
     ROLLUP_RELEASE_NOTES_SCRIPT="$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" \
     GH_CALL_LOG="$gh_call_log" \
     PATH="${bindir}:$PATH" \
+    "$@" \
     bash "$PROJECT_ROOT/src/scripts/runPromoteProdRelease.sh"
+}
+
+@test "default finalize mode tags prod release at finalize commit" {
+  local clone bindir gh_call_log validated_sha finalize_sha tag_sha args
+  clone=$(_promote_prod_init_clone)
+  bindir=$(_write_gh_stub)
+  gh_call_log=$(mktemp)
+  validated_sha=$(git -C "$clone" rev-parse HEAD)
+  cd "$clone" || exit 1
+
+  _run_promote_prod_release "$bindir" "$gh_call_log"
 
   assert_success
   finalize_sha=$(git rev-parse HEAD)
@@ -86,17 +93,7 @@ EOF
   validated_sha=$(git -C "$clone" rev-parse HEAD)
   cd "$clone" || exit 1
 
-  run env GITHUB_TOKEN=fake \
-    GITHUB_REPO_SLUG=example/test \
-    PRIMARY_BRANCH=master \
-    TAG_TARGET=validated \
-    UTC_TIMESTAMP_OVERRIDE=2026-05-08T16:00:00Z \
-    FINALIZE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/finalizeReleaseCycle.mjs" \
-    RESOLVE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/resolveReleaseCycleOnCommit.mjs" \
-    ROLLUP_RELEASE_NOTES_SCRIPT="$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" \
-    GH_CALL_LOG="$gh_call_log" \
-    PATH="${bindir}:$PATH" \
-    bash "$PROJECT_ROOT/src/scripts/runPromoteProdRelease.sh"
+  _run_promote_prod_release "$bindir" "$gh_call_log" TAG_TARGET=validated
 
   assert_success
   finalize_sha=$(git rev-parse HEAD)
@@ -124,17 +121,7 @@ EOF
   validated_sha=$(git -C "$clone" rev-parse HEAD)
   cd "$clone" || exit 1
 
-  run env GITHUB_TOKEN=fake \
-    GITHUB_REPO_SLUG=example/test \
-    PRIMARY_BRANCH=master \
-    TAG_TARGET=validated \
-    UTC_TIMESTAMP_OVERRIDE=2026-05-08T16:00:00Z \
-    FINALIZE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/finalizeReleaseCycle.mjs" \
-    RESOLVE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/resolveReleaseCycleOnCommit.mjs" \
-    ROLLUP_RELEASE_NOTES_SCRIPT="$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" \
-    GH_CALL_LOG="$gh_call_log" \
-    PATH="${bindir}:$PATH" \
-    bash "$PROJECT_ROOT/src/scripts/runPromoteProdRelease.sh"
+  _run_promote_prod_release "$bindir" "$gh_call_log" TAG_TARGET=validated
 
   assert_success
 
@@ -156,18 +143,7 @@ EOF
   gh_call_log=$(mktemp)
   cd "$clone" || exit 1
 
-  run env GITHUB_TOKEN=fake \
-    GITHUB_REPO_SLUG=example/test \
-    PRIMARY_BRANCH=master \
-    RELEASE_ID=2026.05.08.1 \
-    TAG_TARGET=unknown \
-    UTC_TIMESTAMP_OVERRIDE=2026-05-08T16:00:00Z \
-    FINALIZE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/finalizeReleaseCycle.mjs" \
-    RESOLVE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/resolveReleaseCycleOnCommit.mjs" \
-    ROLLUP_RELEASE_NOTES_SCRIPT="$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" \
-    GH_CALL_LOG="$gh_call_log" \
-    PATH="${bindir}:$PATH" \
-    bash "$PROJECT_ROOT/src/scripts/runPromoteProdRelease.sh"
+  _run_promote_prod_release "$bindir" "$gh_call_log" RELEASE_ID=2026.05.08.1 TAG_TARGET=unknown
 
   assert_failure
   assert_output --partial "TAG_TARGET must be finalize or validated"

--- a/test/runPromoteProdRelease.bats
+++ b/test/runPromoteProdRelease.bats
@@ -1,0 +1,174 @@
+#! /usr/bin/env bats
+# shellcheck disable=SC2030,SC2031
+
+setup() {
+  load "helpers/setup"
+  _setup
+}
+
+_promote_prod_init_clone() {
+  local parent bare clone bare_abs
+  parent=$(mktemp -d)
+  bare="${parent}/origin.git"
+  clone="${parent}/work"
+  git init --bare "$bare" >/dev/null 2>&1
+  mkdir -p "$clone"
+  git -C "$clone" init >/dev/null 2>&1
+  git -C "$clone" config user.email test@test
+  git -C "$clone" config user.name Test
+  bare_abs=$(cd "$(dirname "$bare")" && pwd)/$(basename "$bare")
+  git -C "$clone" remote add origin "https://github.com/example/test.git"
+  git -C "$clone" config url."file://${bare_abs}".insteadOf "https://github.com/example/test.git"
+  mkdir -p "${clone}/.releases"
+  cp -a "$PROJECT_ROOT/test/fixtures/release-cycles/2026.05.08.1" "${clone}/.releases/"
+  echo base >"${clone}/README.md"
+  git -C "$clone" add .
+  git -C "$clone" commit -m "rc1 release cycle" >/dev/null 2>&1
+  git -C "$clone" branch -M master >/dev/null 2>&1
+  git -C "$clone" push -u origin master >/dev/null 2>&1
+  printf '%s' "$clone"
+}
+
+_write_gh_stub() {
+  local bindir gh_stub
+  bindir=$(mktemp -d)
+  gh_stub="${bindir}/gh"
+  cat >"$gh_stub" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "release" && "$2" == "view" ]]; then
+  exit 1
+fi
+printf '%s\0' "$*" >>"${GH_CALL_LOG:?GH_CALL_LOG must be set}"
+exit 0
+EOF
+  chmod +x "$gh_stub"
+  printf '%s' "$bindir"
+}
+
+@test "default finalize mode tags prod release at finalize commit" {
+  local clone bindir gh_call_log validated_sha finalize_sha tag_sha args
+  clone=$(_promote_prod_init_clone)
+  bindir=$(_write_gh_stub)
+  gh_call_log=$(mktemp)
+  validated_sha=$(git -C "$clone" rev-parse HEAD)
+  cd "$clone" || exit 1
+
+  run env GITHUB_TOKEN=fake \
+    GITHUB_REPO_SLUG=example/test \
+    PRIMARY_BRANCH=master \
+    UTC_TIMESTAMP_OVERRIDE=2026-05-08T16:00:00Z \
+    FINALIZE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/finalizeReleaseCycle.mjs" \
+    RESOLVE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/resolveReleaseCycleOnCommit.mjs" \
+    ROLLUP_RELEASE_NOTES_SCRIPT="$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" \
+    GH_CALL_LOG="$gh_call_log" \
+    PATH="${bindir}:$PATH" \
+    bash "$PROJECT_ROOT/src/scripts/runPromoteProdRelease.sh"
+
+  assert_success
+  finalize_sha=$(git rev-parse HEAD)
+  [[ "$finalize_sha" != "$validated_sha" ]]
+
+  tag_sha=$(git rev-parse "prod-2026.05.08.1^{commit}")
+  assert_equal "$finalize_sha" "$tag_sha"
+  [[ "$validated_sha" != "$tag_sha" ]]
+
+  args=$(tr '\0' ' ' <"$gh_call_log")
+  [[ "$args" == *"release create"* ]] || false
+  [[ "$args" == *"--target ${finalize_sha}"* ]]
+  [[ "$args" != *"--target ${validated_sha}"* ]]
+}
+
+@test "validated mode tags prod release at pre-finalize commit" {
+  local clone bindir gh_call_log validated_sha finalize_sha tag_sha args
+  clone=$(_promote_prod_init_clone)
+  bindir=$(_write_gh_stub)
+  gh_call_log=$(mktemp)
+  validated_sha=$(git -C "$clone" rev-parse HEAD)
+  cd "$clone" || exit 1
+
+  run env GITHUB_TOKEN=fake \
+    GITHUB_REPO_SLUG=example/test \
+    PRIMARY_BRANCH=master \
+    TAG_TARGET=validated \
+    UTC_TIMESTAMP_OVERRIDE=2026-05-08T16:00:00Z \
+    FINALIZE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/finalizeReleaseCycle.mjs" \
+    RESOLVE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/resolveReleaseCycleOnCommit.mjs" \
+    ROLLUP_RELEASE_NOTES_SCRIPT="$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" \
+    GH_CALL_LOG="$gh_call_log" \
+    PATH="${bindir}:$PATH" \
+    bash "$PROJECT_ROOT/src/scripts/runPromoteProdRelease.sh"
+
+  assert_success
+  finalize_sha=$(git rev-parse HEAD)
+  [[ "$finalize_sha" != "$validated_sha" ]]
+
+  tag_sha=$(git rev-parse "prod-2026.05.08.1^{commit}")
+  assert_equal "$validated_sha" "$tag_sha"
+  [[ "$finalize_sha" != "$tag_sha" ]]
+
+  args=$(tr '\0' ' ' <"$gh_call_log")
+  [[ "$args" == *"release create"* ]] || false
+  [[ "$args" == *"--target ${validated_sha}"* ]]
+  [[ "$args" != *"--target ${finalize_sha}"* ]]
+
+  run git show "${finalize_sha}:.releases/2026.05.08.1/cycle.yml"
+  assert_success
+  assert_output --partial "promotedAt:"
+}
+
+@test "validated mode still pushes finalize artifacts to primary branch" {
+  local clone bindir gh_call_log validated_sha
+  clone=$(_promote_prod_init_clone)
+  bindir=$(_write_gh_stub)
+  gh_call_log=$(mktemp)
+  validated_sha=$(git -C "$clone" rev-parse HEAD)
+  cd "$clone" || exit 1
+
+  run env GITHUB_TOKEN=fake \
+    GITHUB_REPO_SLUG=example/test \
+    PRIMARY_BRANCH=master \
+    TAG_TARGET=validated \
+    UTC_TIMESTAMP_OVERRIDE=2026-05-08T16:00:00Z \
+    FINALIZE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/finalizeReleaseCycle.mjs" \
+    RESOLVE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/resolveReleaseCycleOnCommit.mjs" \
+    ROLLUP_RELEASE_NOTES_SCRIPT="$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" \
+    GH_CALL_LOG="$gh_call_log" \
+    PATH="${bindir}:$PATH" \
+    bash "$PROJECT_ROOT/src/scripts/runPromoteProdRelease.sh"
+
+  assert_success
+
+  git fetch origin master >/dev/null 2>&1
+
+  run git show "origin/master:.releases/2026.05.08.1/cycle.yml"
+  assert_success
+  assert_output --partial "promotedAt:"
+
+  run git rev-parse "origin/master^{commit}"
+  assert_success
+  [[ "$validated_sha" != "$output" ]]
+}
+
+@test "rejects unknown tag-target value" {
+  local clone bindir gh_call_log
+  clone=$(_promote_prod_init_clone)
+  bindir=$(_write_gh_stub)
+  gh_call_log=$(mktemp)
+  cd "$clone" || exit 1
+
+  run env GITHUB_TOKEN=fake \
+    GITHUB_REPO_SLUG=example/test \
+    PRIMARY_BRANCH=master \
+    RELEASE_ID=2026.05.08.1 \
+    TAG_TARGET=unknown \
+    UTC_TIMESTAMP_OVERRIDE=2026-05-08T16:00:00Z \
+    FINALIZE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/finalizeReleaseCycle.mjs" \
+    RESOLVE_RELEASE_CYCLE_SCRIPT="$PROJECT_ROOT/src/scripts/resolveReleaseCycleOnCommit.mjs" \
+    ROLLUP_RELEASE_NOTES_SCRIPT="$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" \
+    GH_CALL_LOG="$gh_call_log" \
+    PATH="${bindir}:$PATH" \
+    bash "$PROJECT_ROOT/src/scripts/runPromoteProdRelease.sh"
+
+  assert_failure
+  assert_output --partial "TAG_TARGET must be finalize or validated"
+}


### PR DESCRIPTION
## Summary
- Adds opt-in `tag-target: validated` to `promote-prod-release` (default `finalize` preserves current behavior).
- With `validated`, `prod-<cycle-id>` and the GitHub Release `--target` point at the pre-finalize `target-ref` commit so deploy pins (e.g. `sha-${CIRCLE_SHA1}`) match the soaked RC build (ADR 0031).
- Finalize artifacts (`promotedAt`, `release-notes.md`) are still committed and pushed to the primary branch for audit.

## Tradeoff
`promotedAt` lives on the finalize commit on primary-branch, not on the tagged commit when using `validated` — a slight deviation from ADR 0042's ideal of co-location on the promotion commit. Consumers needing strict ADR 0042 alignment can stay on `finalize` or stamp `promotedAt` separately later.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (includes new `test/runPromoteProdRelease.bats`)
- [x] Default `finalize` mode still tags at the finalize commit
- [x] `validated` mode tags prod release and GitHub Release at pre-finalize SHA
- [x] Finalize artifacts still pushed to primary branch in `validated` mode


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `tag-target` option for production release promotion to control whether the `prod-*` tag and the GitHub Release target the finalized commit (default) or the pre-finalize validated commit.
  * Ensured release artifacts continue to be published from the primary branch.

* **Bug Fixes**
  * Improved consistency so the production tag and GitHub Release always target the same resolved commit.
  * Added validation to fail fast on unsupported `tag-target` values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->