### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.23.0)

### DIFF
--- a/.changeset/promote-prod-tag-target-validated.md
+++ b/.changeset/promote-prod-tag-target-validated.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": minor
----
-
-Feature: add `tag-target` parameter to `promote-prod-release` so `prod-<cycle-id>` and the GitHub Release can target the pre-finalize validated commit while finalize artifacts still land on the primary branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chiubaka/circleci-orb
 
+## 0.23.0
+
+### Features
+
+- add `tag-target` parameter to `promote-prod-release` so `prod-<cycle-id>` and the GitHub Release can target the pre-finalize validated commit while finalize artifacts still land on the primary branch.
+
 ## 0.22.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### Features

- **@chiubaka/circleci-orb**
  - add `tag-target` parameter to `promote-prod-release` so `prod-<cycle-id>` and the GitHub Release can target the pre-finalize validated commit while finalize artifacts still land on the primary branch.

## Published versions

- `@chiubaka/circleci-orb@0.23.0`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `tag-target` option for production release promotion, allowing the release tag and GitHub Release to point to a validated commit while final artifacts remain on the main branch.

* **Chores**
  * Updated the package version to `0.23.0` and refreshed the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->