### PR TITLE
fix(release): forward primary-branch into promote-prod-release setup

### DIFF
--- a/.changeset/promote-prod-release-primary-branch-setup.md
+++ b/.changeset/promote-prod-release-primary-branch-setup.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fix: Forward `primary-branch` from `promote-prod-release` into nested `setup` so Turbo SCM base uses the configured primary branch instead of defaulting to `master`.

--- a/src/jobs/promote-prod-release.yml
+++ b/src/jobs/promote-prod-release.yml
@@ -82,6 +82,7 @@ steps:
   - setup:
       app-dir: << parameters.app-dir >>
       checkout: true
+      primary-branch: << parameters.primary-branch >>
       skip-pnpm-install: << parameters.skip-install >>
   - promote-prod-release:
       app-dir: << parameters.app-dir >>

--- a/test/jobsForwardPrimaryBranchToSetup.bats
+++ b/test/jobsForwardPrimaryBranchToSetup.bats
@@ -23,7 +23,10 @@ for path in sorted((root / "src" / "jobs").glob("*.yml")):
         continue
     for match in setup_block.finditer(text):
         block = match.group(1)
-        if expected not in block:
+        if not re.search(
+            rf"(?m)^      {re.escape(expected)}[ \t]*$",
+            block,
+        ):
             failures.append(path.relative_to(root).as_posix())
 
 if failures:

--- a/test/jobsForwardPrimaryBranchToSetup.bats
+++ b/test/jobsForwardPrimaryBranchToSetup.bats
@@ -1,0 +1,38 @@
+#! /usr/bin/env bats
+
+setup() {
+  load "helpers/setup"
+  _setup
+}
+
+@test "jobs that accept primary-branch forward it into nested setup" {
+  run python3 - "$PROJECT_ROOT" <<'PY'
+from pathlib import Path
+import sys
+
+import yaml
+
+root = Path(sys.argv[1])
+failures = []
+
+for path in sorted((root / "src" / "jobs").glob("*.yml")):
+    doc = yaml.safe_load(path.read_text())
+    params = doc.get("parameters") or {}
+    if "primary-branch" not in params:
+        continue
+    for step in doc.get("steps") or []:
+        if not isinstance(step, dict) or "setup" not in step:
+            continue
+        setup = step["setup"] or {}
+        if "primary-branch" not in setup:
+            failures.append(path.relative_to(root).as_posix())
+        break
+
+if failures:
+    print("Jobs missing primary-branch forward to setup:")
+    for failure in failures:
+        print(f"  {failure}")
+    sys.exit(1)
+PY
+  assert_success
+}

--- a/test/jobsForwardPrimaryBranchToSetup.bats
+++ b/test/jobsForwardPrimaryBranchToSetup.bats
@@ -6,27 +6,25 @@ setup() {
 }
 
 @test "jobs that accept primary-branch forward it into nested setup" {
+  # Avoid PyYAML: CircleCI bats image has no yaml module. Stdlib-only scan.
   run python3 - "$PROJECT_ROOT" <<'PY'
 from pathlib import Path
+import re
 import sys
-
-import yaml
 
 root = Path(sys.argv[1])
 failures = []
+expected = "primary-branch: << parameters.primary-branch >>"
+setup_block = re.compile(r"(?m)^  - setup:\n((?:      .*\n)*)")
 
 for path in sorted((root / "src" / "jobs").glob("*.yml")):
-    doc = yaml.safe_load(path.read_text())
-    params = doc.get("parameters") or {}
-    if "primary-branch" not in params:
+    text = path.read_text()
+    if not re.search(r"(?m)^  primary-branch:\s*$", text):
         continue
-    for step in doc.get("steps") or []:
-        if not isinstance(step, dict) or "setup" not in step:
-            continue
-        setup = step["setup"] or {}
-        if "primary-branch" not in setup:
+    for match in setup_block.finditer(text):
+        block = match.group(1)
+        if expected not in block:
             failures.append(path.relative_to(root).as_posix())
-        break
 
 if failures:
     print("Jobs missing primary-branch forward to setup:")


### PR DESCRIPTION
## Summary
- Forward `primary-branch` from the `promote-prod-release` job into nested `setup`, so Turbo SCM base uses the configured branch instead of defaulting to `master`.
- Add a bats regression that asserts every job accepting `primary-branch` and calling `setup` forwards the parameter.
- Patch changeset for `@chiubaka/circleci-orb`.

Fixes client failures on `main`-default repos (e.g. `snowdayedu/data-platform`) where `git fetch origin master` failed during **Set Turbo SCM base for affected detection**.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (includes new `jobsForwardPrimaryBranchToSetup` test)
- [ ] Confirm packed orb job wires `setup.primary-branch` (local `circleci orb pack` check done)
- [ ] After release, re-run `promote-prod-release` on a `main` client with `primary-branch: main`


Made with [Cursor](https://cursor.com)