### PR TITLE
fix(orb): default target-ref to empty for non-VCS pipelines

### DIFF
--- a/.changeset/empty-target-ref-default.md
+++ b/.changeset/empty-target-ref-default.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fix: default `target-ref` to empty on promote/tag/release commands so pipelines without `pipeline.git.revision` (API/schedule triggers) still compile; scripts already fall back to `CIRCLE_SHA1` or `HEAD`.

--- a/src/commands/github-release-train.yml
+++ b/src/commands/github-release-train.yml
@@ -37,10 +37,10 @@ parameters:
       Overriding can break parity with release train identifiers and manifests (ADRs 0038, 0039).
   target-ref:
     type: string
-    default: "<< pipeline.git.revision >>"
+    default: ""
     description: >
-      Commit or ref passed to gh --target (defaults to the pipeline revision). Empty falls back to
-      CIRCLE_SHA1 or HEAD in the script.
+      Commit or ref passed to gh --target. Empty (default) falls back to CIRCLE_SHA1 or HEAD
+      in the script so config compile does not require pipeline.git.revision.
   on-existing-tag:
     type: enum
     enum:

--- a/src/commands/promote-prod-release.yml
+++ b/src/commands/promote-prod-release.yml
@@ -28,8 +28,10 @@ parameters:
     description: Optional cycle id override (YYYY.MM.DD.N). When empty, inferred from .releases/ on the commit.
   target-ref:
     type: string
-    default: "<< pipeline.git.revision >>"
-    description: Commit to finalize and tag (defaults to pipeline revision).
+    default: ""
+    description: >
+      Commit to finalize and tag. Empty (default) falls back to CIRCLE_SHA1 or HEAD
+      in the script so config compile does not require pipeline.git.revision.
   tag-target:
     type: enum
     enum:

--- a/src/commands/push-promotion-tag.yml
+++ b/src/commands/push-promotion-tag.yml
@@ -23,8 +23,10 @@ parameters:
       Environment prefix without trailing hyphen (e.g. staging, prod). Empty disables this step.
   target-ref:
     type: string
-    default: "<< pipeline.git.revision >>"
-    description: Commit to tag (defaults to pipeline revision / CIRCLE_SHA1 in script).
+    default: ""
+    description: >
+      Commit to tag. Empty (default) falls back to CIRCLE_SHA1 or HEAD in the script
+      so config compile does not require pipeline.git.revision.
 
 steps:
   - run:

--- a/src/jobs/promote-prod-release.yml
+++ b/src/jobs/promote-prod-release.yml
@@ -27,8 +27,10 @@ parameters:
     default: ""
   target-ref:
     type: string
-    default: "<< pipeline.git.revision >>"
-    description: Commit to finalize and tag (defaults to pipeline revision).
+    default: ""
+    description: >
+      Commit to finalize and tag. Empty (default) falls back to CIRCLE_SHA1 or HEAD
+      in the script so config compile does not require pipeline.git.revision.
   tag-target:
     type: enum
     enum:

--- a/test/targetRefParameterDefaults.bats
+++ b/test/targetRefParameterDefaults.bats
@@ -1,0 +1,53 @@
+#! /usr/bin/env bats
+
+setup() {
+  load "helpers/setup"
+  _setup
+}
+
+# CircleCI fails config compile when an orb parameter default expands
+# << pipeline.git.revision >> in pipelines that lack that value (API/schedule/etc.).
+# Defaults must be empty so scripts can fall back to CIRCLE_SHA1 / HEAD at runtime.
+
+@test "parameter defaults do not expand pipeline.git.revision" {
+  run grep -R --include='*.yml' -n 'default:.*"\?<<[[:space:]]*pipeline\.git\.revision' \
+    "$PROJECT_ROOT/src/commands" "$PROJECT_ROOT/src/jobs"
+  assert_failure
+  assert_equal "$output" ""
+}
+
+_assert_target_ref_empty_default() {
+  local file=$1
+  local block
+  block=$(sed -n '/^parameters:/,/^[^[:space:]#]/p' "$file" | grep -A8 -E '^[[:space:]]*target-ref:')
+  [[ -n "$block" ]] || {
+    echo "no target-ref parameter in ${file}" >&2
+    return 1
+  }
+  [[ "$block" == *'default: ""'* ]] || {
+    echo "expected empty string default in target-ref block of ${file}:" >&2
+    echo "$block" >&2
+    return 1
+  }
+  [[ "$block" != *'<< pipeline.git.revision >>'* ]] || {
+    echo "target-ref default still references pipeline.git.revision in ${file}:" >&2
+    echo "$block" >&2
+    return 1
+  }
+}
+
+@test "promote-prod-release job target-ref defaults to empty string" {
+  _assert_target_ref_empty_default "$PROJECT_ROOT/src/jobs/promote-prod-release.yml"
+}
+
+@test "promote-prod-release command target-ref defaults to empty string" {
+  _assert_target_ref_empty_default "$PROJECT_ROOT/src/commands/promote-prod-release.yml"
+}
+
+@test "push-promotion-tag target-ref defaults to empty string" {
+  _assert_target_ref_empty_default "$PROJECT_ROOT/src/commands/push-promotion-tag.yml"
+}
+
+@test "github-release-train target-ref defaults to empty string" {
+  _assert_target_ref_empty_default "$PROJECT_ROOT/src/commands/github-release-train.yml"
+}


### PR DESCRIPTION
## Summary
- Change `target-ref` defaults on `promote-prod-release`, `push-promotion-tag`, and `github-release-train` from `<< pipeline.git.revision >>` to `""` so CircleCI config compile succeeds when that pipeline value is absent (API/schedule triggers).
- Runtime resolution is unchanged: empty still falls back to `CIRCLE_SHA1` or `HEAD` in the scripts.
- Add regression tests and a patch changeset.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test`
- [x] `circleci orb pack src` shows `target-ref` defaults as `""`
- [ ] Confirm a client pipeline that previously failed with `pipeline.git.revision` does not exist now compiles with the published orb (or `@dev` label)

Made with [Cursor](https://cursor.com)