### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.24.1)

### DIFF
--- a/.changeset/capitalized-summary-after-prefix.md
+++ b/.changeset/capitalized-summary-after-prefix.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Improvement: Require sentence-case summary text after category prefixes in verify-changesets.

--- a/.changeset/empty-target-ref-default.md
+++ b/.changeset/empty-target-ref-default.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: default `target-ref` to empty on promote/tag/release commands so pipelines without `pipeline.git.revision` (API/schedule triggers) still compile; scripts already fall back to `CIRCLE_SHA1` or `HEAD`.

--- a/.changeset/promote-prod-release-primary-branch-setup.md
+++ b/.changeset/promote-prod-release-primary-branch-setup.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: Forward `primary-branch` from `promote-prod-release` into nested `setup` so Turbo SCM base uses the configured primary branch instead of defaulting to `master`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @chiubaka/circleci-orb
 
+## 0.24.1
+
+### Improvements
+
+- Require sentence-case summary text after category prefixes in verify-changesets.
+
+### Bug Fixes
+
+- default `target-ref` to empty on promote/tag/release commands so pipelines without `pipeline.git.revision` (API/schedule triggers) still compile; scripts already fall back to `CIRCLE_SHA1` or `HEAD`.
+- Forward `primary-branch` from `promote-prod-release` into nested `setup` so Turbo SCM base uses the configured primary branch instead of defaulting to `master`.
+
 ## 0.24.0
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### @chiubaka/circleci-orb

#### Improvements

- Require sentence-case summary text after category prefixes in verify-changesets.

#### Bug Fixes

- default `target-ref` to empty on promote/tag/release commands so pipelines without `pipeline.git.revision` (API/schedule triggers) still compile; scripts already fall back to `CIRCLE_SHA1` or `HEAD`.
- Forward `primary-branch` from `promote-prod-release` into nested `setup` so Turbo SCM base uses the configured primary branch instead of defaulting to `master`.

## Published versions

- `@chiubaka/circleci-orb@0.24.1`
