### PR TITLE
feat(changesets): require sentence-case summaries after category prefixes

### DIFF
--- a/.changeset/capitalized-summary-after-prefix.md
+++ b/.changeset/capitalized-summary-after-prefix.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Improvement: Require sentence-case summary text after category prefixes in verify-changesets.

--- a/org/agents/skills/changeset/SKILL.md
+++ b/org/agents/skills/changeset/SKILL.md
@@ -25,7 +25,7 @@ For **ADR-only** or **agent-guidance-only** PRs (no changes to shipped packages,
 1. **Confirm the repo uses Changesets** (`.changeset/config.json`, `@changesets/cli`).
 2. **Determine monorepo type** for the packages in the frontmatter (library, app/deployable, or hybrid). This sets **voice** only.
 3. **Choose a category prefix** from the taxonomy below. Prefixes are **required in all org repos** — not optional for library monorepos.
-4. **Write the headline** after the prefix using the voice for that monorepo type. Start the summary in **sentence case** (capitalize the first letter after the prefix).
+4. **Write the headline** after the prefix using the voice for that monorepo type. Use **sentence case** when the summary starts with a letter; non-letter starts are allowed.
 5. **Set semver** in frontmatter independently of category (a bug fix can be `major` if breaking; a feature can be `patch` if additive and non-breaking).
 
 **Anti-patterns**
@@ -113,7 +113,7 @@ App monorepos still use **`Breaking:`** or **`Deprecation:`** when users must ch
 **The first line after the closing `---` is the changelog headline** — prefix plus summary. Release tooling strips the prefix token when rendering grouped changelogs; author with the prefix in the changeset file.
 
 - **Prefix required** — start with an accepted category token (see [Full taxonomy](#full-taxonomy)).
-- **Sentence case after prefix** — capitalize the first letter of the summary (after `: `). Non-letter starts such as `` ` ``, `"`, or a digit are allowed.
+- **Sentence case after prefix** — capitalize the first letter when the summary starts with a letter. Non-letter starts such as backticks, quotation marks, or a digit are allowed.
 - **One short line** — clear, scannable, **like a release note bullet**, not a paragraph.
 - **Self-contained** — the headline (after prefix) should stand alone. Do not rely on a body paragraph.
 - **Impact over implementation** — state what consumers must know (new option, stricter validation, removed export), not how the code was refactored. Technical terms are fine when they are the consumer-facing contract (API names, config keys, breaking types).

--- a/org/agents/skills/changeset/SKILL.md
+++ b/org/agents/skills/changeset/SKILL.md
@@ -25,7 +25,7 @@ For **ADR-only** or **agent-guidance-only** PRs (no changes to shipped packages,
 1. **Confirm the repo uses Changesets** (`.changeset/config.json`, `@changesets/cli`).
 2. **Determine monorepo type** for the packages in the frontmatter (library, app/deployable, or hybrid). This sets **voice** only.
 3. **Choose a category prefix** from the taxonomy below. Prefixes are **required in all org repos** — not optional for library monorepos.
-4. **Write the headline** after the prefix using the voice for that monorepo type.
+4. **Write the headline** after the prefix using the voice for that monorepo type. Start the summary in **sentence case** (capitalize the first letter after the prefix).
 5. **Set semver** in frontmatter independently of category (a bug fix can be `major` if breaking; a feature can be `patch` if additive and non-breaking).
 
 **Anti-patterns**
@@ -33,6 +33,7 @@ For **ADR-only** or **agent-guidance-only** PRs (no changes to shipped packages,
 - Do **not** pick a prefix because the _work_ mentions “features” (for example, building category-prefix support ≠ automatically `Feature:` — classify by **consumer impact**).
 - Do **not** omit a prefix expecting silent fallback — use **`Other:`** explicitly when no other category fits.
 - Do **not** conflate prefix with voice: library repos use prefixes too; the text after the prefix stays **technical**.
+- Do **not** leave the summary after the prefix lowercase (`Other: upgrade …`) — use sentence case (`Other: Upgrade …`). Release tooling strips the prefix, so the remaining bullet must read as a standalone capitalized sentence.
 
 ## Monorepo type (choose the right voice)
 
@@ -112,6 +113,7 @@ App monorepos still use **`Breaking:`** or **`Deprecation:`** when users must ch
 **The first line after the closing `---` is the changelog headline** — prefix plus summary. Release tooling strips the prefix token when rendering grouped changelogs; author with the prefix in the changeset file.
 
 - **Prefix required** — start with an accepted category token (see [Full taxonomy](#full-taxonomy)).
+- **Sentence case after prefix** — capitalize the first letter of the summary (after `: `). Non-letter starts such as `` ` ``, `"`, or a digit are allowed.
 - **One short line** — clear, scannable, **like a release note bullet**, not a paragraph.
 - **Self-contained** — the headline (after prefix) should stand alone. Do not rely on a body paragraph.
 - **Impact over implementation** — state what consumers must know (new option, stricter validation, removed export), not how the code was refactored. Technical terms are fine when they are the consumer-facing contract (API names, config keys, breaking types).
@@ -159,6 +161,18 @@ Disable `react/react-in-jsx-scope` in the default React preset.
 
 Fix: add a category prefix, for example `Improvement: Disable …`.
 
+### Bad example — library (lowercase after prefix)
+
+```markdown
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Other: upgrade CI to the latest orb release.
+```
+
+Fix: capitalize the summary after the prefix, for example `Other: Upgrade CI to the latest orb release.`.
+
 ### Bad example — library (first line too long)
 
 ```markdown
@@ -178,6 +192,7 @@ Fix: keep a **single** crisp sentence after the prefix; put migration detail in 
 **The first line after the closing `---` is the release note headline** — prefix plus product-oriented summary.
 
 - **Prefix required** — same taxonomy as library repos.
+- **Sentence case after prefix** — same capitalization rule as library monorepos.
 - **Product language** — describe what users see, can do, or no longer struggle with.
 - **No technical concepts** — avoid API routes, database tables, package names, refactors, “backend/frontend,” framework names, and other implementation vocabulary unless it is the **user-visible product name** (for example, a branded integration users recognize).
 - **One short line** — same brevity rules as library monorepos.
@@ -255,6 +270,7 @@ Breaking: Require `AuthClientOptions.region` and remove the deprecated `apiHost`
 
 - [ ] Identified **monorepo type** (library, app/deployable, or hybrid) and matched **voice** for text after the prefix.
 - [ ] **Category prefix** present and appropriate (`Breaking:`, `Feature:`, `Fix:`, `Other:`, etc.).
+- [ ] Summary after the prefix is **sentence case** (capitalized; not `Other: upgrade …`).
 - [ ] Frontmatter lists every affected **published package or deployable artifact** with the right **semver** bump (independent of category).
 - [ ] **First line** after `---` is prefix + crisp, self-contained summary.
 - [ ] **No body** unless the audience needs migration or must-know steps that cannot fit in the headline alone.

--- a/org/agents/skills/review/SKILL.md
+++ b/org/agents/skills/review/SKILL.md
@@ -48,7 +48,7 @@ Run by default after any non-trivial code change and **before** you tell the use
 - [ ] Keep skill scope narrow; avoid restating broad org conventions when cross-referencing is sufficient.
 - [ ] Run guidance sync scripts after org-level guidance or skill changes.
 - [ ] On repositories with Changesets, when the PR includes **releasable** work (behavior, APIs, orb/scripts, publishable configs), confirm release notes and semver bumps are expressed via a **new or updated** `.changeset/*.md` entry, **not** by editing `package.json` `version` or `CHANGELOG.md` directly, unless a maintainer asked for a hotfix to automation itself (see `org/agents/skills/changesets-hygiene/SKILL.md`). **Skip** this check when the change is **ADRs or agent guidance only** (no changeset expected per that skill).
-- [ ] When reviewing a `.changeset/*.md` entry, confirm the summary follows `org/agents/skills/changeset/SKILL.md`: **category prefix** on the headline, **voice** matched to monorepo type (technical for library packages, product-oriented for deployable artifacts), and semver in frontmatter independent of category.
+- [ ] When reviewing a `.changeset/*.md` entry, confirm the summary follows `org/agents/skills/changeset/SKILL.md`: **category prefix** on the headline, **sentence case** after the prefix, **voice** matched to monorepo type (technical for library packages, product-oriented for deployable artifacts), and semver in frontmatter independent of category.
 
 ## Style and naming
 

--- a/src/scripts/changesetCategoryPrefixes.mjs
+++ b/src/scripts/changesetCategoryPrefixes.mjs
@@ -119,6 +119,20 @@ export function stripCategoryPrefix(text) {
 }
 
 /**
+ * True when the summary after a recognized category prefix uses sentence case:
+ * the first character must not be a lowercase letter (uppercase letters and
+ * non-letters such as digits, backticks, or quotes are allowed).
+ *
+ * @param {string} headline Prefixed summary headline (first line of a changeset body).
+ * @returns {boolean}
+ */
+export function hasCapitalizedSummaryAfterPrefix(headline) {
+  const summary = stripCategoryPrefix(headline).trimStart();
+  if (!summary) return false;
+  return !/\p{Ll}/u.test(summary[0]);
+}
+
+/**
  * Strip Changesets changelog bullet metadata before category matching.
  * `@changesets/cli/changelog` re-exports `@changesets/changelog-git`, which prefixes bullets with
  * `<shortSha>: ` when a changeset commit is known. `@changesets/changelog-github` may prefix with
@@ -218,6 +232,14 @@ export function validateChangesetSummaryCategory(content) {
       ok: false,
       error:
         `summary headline must start with a category prefix (Breaking:, Security:, Feature:, Fix:, Deprecation:, Other:, etc.); ` +
+        `got: ${JSON.stringify(headline)}`,
+    };
+  }
+  if (!hasCapitalizedSummaryAfterPrefix(headline)) {
+    return {
+      ok: false,
+      error:
+        `summary text after the category prefix must be capitalized (sentence case); ` +
         `got: ${JSON.stringify(headline)}`,
     };
   }

--- a/src/scripts/changesetCategoryPrefixes.mjs
+++ b/src/scripts/changesetCategoryPrefixes.mjs
@@ -129,7 +129,8 @@ export function stripCategoryPrefix(text) {
 export function hasCapitalizedSummaryAfterPrefix(headline) {
   const summary = stripCategoryPrefix(headline).trimStart();
   if (!summary) return false;
-  return !/\p{Ll}/u.test(summary[0]);
+  const firstCharacter = [...summary][0];
+  return !/\p{Ll}/u.test(firstCharacter);
 }
 
 /**

--- a/src/scripts/stageChangesetCategoryPrefixScripts.sh
+++ b/src/scripts/stageChangesetCategoryPrefixScripts.sh
@@ -137,7 +137,8 @@ export function stripCategoryPrefix(text) {
 export function hasCapitalizedSummaryAfterPrefix(headline) {
   const summary = stripCategoryPrefix(headline).trimStart();
   if (!summary) return false;
-  return !/\p{Ll}/u.test(summary[0]);
+  const firstCharacter = [...summary][0];
+  return !/\p{Ll}/u.test(firstCharacter);
 }
 
 /**

--- a/src/scripts/stageChangesetCategoryPrefixScripts.sh
+++ b/src/scripts/stageChangesetCategoryPrefixScripts.sh
@@ -127,6 +127,20 @@ export function stripCategoryPrefix(text) {
 }
 
 /**
+ * True when the summary after a recognized category prefix uses sentence case:
+ * the first character must not be a lowercase letter (uppercase letters and
+ * non-letters such as digits, backticks, or quotes are allowed).
+ *
+ * @param {string} headline Prefixed summary headline (first line of a changeset body).
+ * @returns {boolean}
+ */
+export function hasCapitalizedSummaryAfterPrefix(headline) {
+  const summary = stripCategoryPrefix(headline).trimStart();
+  if (!summary) return false;
+  return !/\p{Ll}/u.test(summary[0]);
+}
+
+/**
  * Strip Changesets changelog bullet metadata before category matching.
  * `@changesets/cli/changelog` re-exports `@changesets/changelog-git`, which prefixes bullets with
  * `<shortSha>: ` when a changeset commit is known. `@changesets/changelog-github` may prefix with
@@ -229,6 +243,14 @@ export function validateChangesetSummaryCategory(content) {
         `got: ${JSON.stringify(headline)}`,
     };
   }
+  if (!hasCapitalizedSummaryAfterPrefix(headline)) {
+    return {
+      ok: false,
+      error:
+        `summary text after the category prefix must be capitalized (sentence case); ` +
+        `got: ${JSON.stringify(headline)}`,
+    };
+  }
   return { ok: true, headline, bucket };
 }
 
@@ -255,7 +277,6 @@ export function formatAcceptedPrefixesList() {
     (g) => `${g.section}: ${g.prefixes.join(", ")}`,
   ).join("; ");
 }
-
 CHIUBAKA_ORB_CATEGORY_PREFIXES_V1_EOF
 cat >"$verify_out" <<'CHIUBAKA_ORB_VERIFY_CATEGORY_PREFIXES_V1_EOF'
 #!/usr/bin/env node

--- a/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
+++ b/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
@@ -126,6 +126,20 @@ export function stripCategoryPrefix(text) {
 }
 
 /**
+ * True when the summary after a recognized category prefix uses sentence case:
+ * the first character must not be a lowercase letter (uppercase letters and
+ * non-letters such as digits, backticks, or quotes are allowed).
+ *
+ * @param {string} headline Prefixed summary headline (first line of a changeset body).
+ * @returns {boolean}
+ */
+export function hasCapitalizedSummaryAfterPrefix(headline) {
+  const summary = stripCategoryPrefix(headline).trimStart();
+  if (!summary) return false;
+  return !/\p{Ll}/u.test(summary[0]);
+}
+
+/**
  * Strip Changesets changelog bullet metadata before category matching.
  * `@changesets/cli/changelog` re-exports `@changesets/changelog-git`, which prefixes bullets with
  * `<shortSha>: ` when a changeset commit is known. `@changesets/changelog-github` may prefix with
@@ -228,6 +242,14 @@ export function validateChangesetSummaryCategory(content) {
         `got: ${JSON.stringify(headline)}`,
     };
   }
+  if (!hasCapitalizedSummaryAfterPrefix(headline)) {
+    return {
+      ok: false,
+      error:
+        `summary text after the category prefix must be capitalized (sentence case); ` +
+        `got: ${JSON.stringify(headline)}`,
+    };
+  }
   return { ok: true, headline, bucket };
 }
 
@@ -254,7 +276,6 @@ export function formatAcceptedPrefixesList() {
     (g) => `${g.section}: ${g.prefixes.join(", ")}`,
   ).join("; ");
 }
-
 CHIUBAKA_ORB_CATEGORY_PREFIXES_V1_EOF
 out=${FORMAT_CHANGESETS_BATCH_STAGE_PATH:-/tmp/chiubaka-formatChangesetsBatchReleaseNotes.mjs}
 cat >"$out" <<'CHIUBAKA_ORB_FORMATTER_V1_EOF'

--- a/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
+++ b/src/scripts/stageFormatChangesetsBatchReleaseNotes.sh
@@ -136,7 +136,8 @@ export function stripCategoryPrefix(text) {
 export function hasCapitalizedSummaryAfterPrefix(headline) {
   const summary = stripCategoryPrefix(headline).trimStart();
   if (!summary) return false;
-  return !/\p{Ll}/u.test(summary[0]);
+  const firstCharacter = [...summary][0];
+  return !/\p{Ll}/u.test(firstCharacter);
 }
 
 /**

--- a/src/scripts/stageReleaseCycleWriter.sh
+++ b/src/scripts/stageReleaseCycleWriter.sh
@@ -1636,7 +1636,8 @@ export function stripCategoryPrefix(text) {
 export function hasCapitalizedSummaryAfterPrefix(headline) {
   const summary = stripCategoryPrefix(headline).trimStart();
   if (!summary) return false;
-  return !/\p{Ll}/u.test(summary[0]);
+  const firstCharacter = [...summary][0];
+  return !/\p{Ll}/u.test(firstCharacter);
 }
 
 /**

--- a/src/scripts/stageReleaseCycleWriter.sh
+++ b/src/scripts/stageReleaseCycleWriter.sh
@@ -1626,6 +1626,20 @@ export function stripCategoryPrefix(text) {
 }
 
 /**
+ * True when the summary after a recognized category prefix uses sentence case:
+ * the first character must not be a lowercase letter (uppercase letters and
+ * non-letters such as digits, backticks, or quotes are allowed).
+ *
+ * @param {string} headline Prefixed summary headline (first line of a changeset body).
+ * @returns {boolean}
+ */
+export function hasCapitalizedSummaryAfterPrefix(headline) {
+  const summary = stripCategoryPrefix(headline).trimStart();
+  if (!summary) return false;
+  return !/\p{Ll}/u.test(summary[0]);
+}
+
+/**
  * Strip Changesets changelog bullet metadata before category matching.
  * `@changesets/cli/changelog` re-exports `@changesets/changelog-git`, which prefixes bullets with
  * `<shortSha>: ` when a changeset commit is known. `@changesets/changelog-github` may prefix with
@@ -1725,6 +1739,14 @@ export function validateChangesetSummaryCategory(content) {
       ok: false,
       error:
         `summary headline must start with a category prefix (Breaking:, Security:, Feature:, Fix:, Deprecation:, Other:, etc.); ` +
+        `got: ${JSON.stringify(headline)}`,
+    };
+  }
+  if (!hasCapitalizedSummaryAfterPrefix(headline)) {
+    return {
+      ok: false,
+      error:
+        `summary text after the category prefix must be capitalized (sentence case); ` +
         `got: ${JSON.stringify(headline)}`,
     };
   }

--- a/test/changesetCategoryPrefixes.bats
+++ b/test/changesetCategoryPrefixes.bats
@@ -81,6 +81,37 @@ setup() {
   assert_success
 }
 
+@test "validateChangesetSummaryCategory rejects lowercase summary after prefix" {
+  run node -e "
+    import { validateChangesetSummaryCategory } from '$PREFIXES';
+    const content = '---\\n\"@t/pkg\": patch\\n---\\n\\nOther: upgrade CI tooling\\n';
+    const r = validateChangesetSummaryCategory(content);
+    if (r.ok) process.exit(1);
+    if (!r.error.includes('must be capitalized')) process.exit(2);
+  "
+  assert_success
+}
+
+@test "validateChangesetSummaryCategory allows non-letter starts after prefix" {
+  run node -e "
+    import { validateChangesetSummaryCategory } from '$PREFIXES';
+    const cases = [
+      'Fix: \`foo\` no longer throws',
+      'Feature: 2x faster search',
+      'Improvement: \"Quoted\" label',
+    ];
+    for (const summary of cases) {
+      const content = '---\\n\"@t/pkg\": patch\\n---\\n\\n' + summary + '\\n';
+      const r = validateChangesetSummaryCategory(content);
+      if (!r.ok) {
+        console.error(summary, r.error);
+        process.exit(1);
+      }
+    }
+  "
+  assert_success
+}
+
 @test "isEmptyChangeset recognizes changeset add --empty format" {
   run node -e "
     import { isEmptyChangeset, validateChangesetSummaryCategory } from '$PREFIXES';

--- a/test/changesetCategoryPrefixes.bats
+++ b/test/changesetCategoryPrefixes.bats
@@ -92,6 +92,28 @@ setup() {
   assert_success
 }
 
+@test "validateChangesetSummaryCategory rejects empty summary after prefix" {
+  run node -e "
+    import { validateChangesetSummaryCategory } from '$PREFIXES';
+    const content = '---\\n\"@t/pkg\": patch\\n---\\n\\nOther:\\n';
+    const r = validateChangesetSummaryCategory(content);
+    if (r.ok) process.exit(1);
+    if (!r.error.includes('must be capitalized')) process.exit(2);
+  "
+  assert_success
+}
+
+@test "validateChangesetSummaryCategory rejects lowercase astral letter after prefix" {
+  run node -e "
+    import { validateChangesetSummaryCategory } from '$PREFIXES';
+    const content = '---\\n\"@t/pkg\": patch\\n---\\n\\nOther: \\u{10428}deseret lowercase\\n';
+    const r = validateChangesetSummaryCategory(content);
+    if (r.ok) process.exit(1);
+    if (!r.error.includes('must be capitalized')) process.exit(2);
+  "
+  assert_success
+}
+
 @test "validateChangesetSummaryCategory allows non-letter starts after prefix" {
   run node -e "
     import { validateChangesetSummaryCategory } from '$PREFIXES';

--- a/test/formatChangesetsBatchReleaseNotes.bats
+++ b/test/formatChangesetsBatchReleaseNotes.bats
@@ -99,8 +99,8 @@ EOF
   local out
   cd "$BATS_TEST_TMPDIR" || exit 1
   _make_pkg_changelog app 1.0.0 "### Minor Changes
-- Feature: ship new dashboard
-- Fix: handle empty state"
+- Feature: Ship new dashboard
+- Fix: Handle empty state"
 
   out=$(mktemp)
   run env RELEASE_NOTES_GROUPING=category node "$FORMATTER" "$out" app/CHANGELOG.md
@@ -110,9 +110,9 @@ EOF
   assert_success
   run grep -F "#### Bug Fixes" "$out"
   assert_success
-  run grep -F "ship new dashboard" "$out"
+  run grep -F "Ship new dashboard" "$out"
   assert_success
-  run grep -F "handle empty state" "$out"
+  run grep -F "Handle empty state" "$out"
   assert_success
   run grep -F "### Minor Changes" "$out"
   assert_failure
@@ -181,7 +181,7 @@ EOF
 @test "category mode places Other-prefixed bullets under Other Changes" {
   local out
   cd "$BATS_TEST_TMPDIR" || exit 1
-  _make_pkg_changelog app 1.0.0 "- Other: internal dependency maintenance"
+  _make_pkg_changelog app 1.0.0 "- Other: Internal dependency maintenance"
 
   out=$(mktemp)
   run env RELEASE_NOTES_GROUPING=category node "$FORMATTER" "$out" app/CHANGELOG.md
@@ -189,7 +189,7 @@ EOF
 
   run grep -F "#### Other Changes" "$out"
   assert_success
-  run grep -F "internal dependency maintenance" "$out"
+  run grep -F "Internal dependency maintenance" "$out"
   assert_success
   run grep -F "Other:" "$out"
   assert_failure
@@ -200,19 +200,19 @@ EOF
   local out
   cd "$BATS_TEST_TMPDIR" || exit 1
   _make_pkg_changelog app 1.0.0 "### Other Changes
-- Other: tagged other entry
+- Other: Tagged other entry
 ### Deprecations
-- Deprecation: old API
+- Deprecation: Old API
 ### Bug Fixes
-- Fix: bug
+- Fix: Bug
 ### Improvements
-- Improvement: imp
+- Improvement: Imp
 ### Features
-- Feature: feat
+- Feature: Feat
 ### Security
-- Security: patch CVE
+- Security: Patch CVE
 ### Breaking Changes
-- Breaking: remove endpoint"
+- Breaking: Remove endpoint"
 
   out=$(mktemp)
   run env RELEASE_NOTES_GROUPING=category node "$FORMATTER" "$out" app/CHANGELOG.md
@@ -229,9 +229,9 @@ EOF
 @test "category mode places Breaking Security and Deprecation bullets under correct headings" {
   local out
   cd "$BATS_TEST_TMPDIR" || exit 1
-  _make_pkg_changelog lib 2.0.0 "- Breaking: drop legacy export
-- Security: rotate signing keys
-- Deprecation: prefer new client"
+  _make_pkg_changelog lib 2.0.0 "- Breaking: Drop legacy export
+- Security: Rotate signing keys
+- Deprecation: Prefer new client"
 
   out=$(mktemp)
   run env RELEASE_NOTES_GROUPING=category node "$FORMATTER" "$out" lib/CHANGELOG.md
@@ -243,11 +243,11 @@ EOF
   assert_success
   run grep -F "#### Deprecations" "$out"
   assert_success
-  run grep -F "drop legacy export" "$out"
+  run grep -F "Drop legacy export" "$out"
   assert_success
-  run grep -F "rotate signing keys" "$out"
+  run grep -F "Rotate signing keys" "$out"
   assert_success
-  run grep -F "prefer new client" "$out"
+  run grep -F "Prefer new client" "$out"
   assert_success
   rm -f "$out"
 }
@@ -256,13 +256,13 @@ EOF
   local out
   cd "$BATS_TEST_TMPDIR" || exit 1
   _make_pkg_changelog app 1.0.0 "### Other Changes
-- Other: tagged other entry
+- Other: Tagged other entry
 ### Bug Fixes
-- Fix: bug
+- Fix: Bug
 ### Features
-- Feature: feat
+- Feature: Feat
 ### Improvements
-- Improvement: imp"
+- Improvement: Imp"
 
   out=$(mktemp)
   run env RELEASE_NOTES_GROUPING=category node "$FORMATTER" "$out" app/CHANGELOG.md

--- a/test/rewriteChangelogCategories.bats
+++ b/test/rewriteChangelogCategories.bats
@@ -19,7 +19,7 @@ setup() {
 - Deprecation: Old client helper
 ### Patch Changes
 - Fix: Correct typo
-- Other: ops-only note
+- Other: Ops-only note
 EOF
 
   run node "$REWRITER" pkg/CHANGELOG.md
@@ -51,7 +51,7 @@ EOF
   assert_success
   run grep -F "Correct typo" pkg/CHANGELOG.md
   assert_success
-  run grep -F "ops-only note" pkg/CHANGELOG.md
+  run grep -F "Ops-only note" pkg/CHANGELOG.md
   assert_success
   run grep -F "Breaking:" pkg/CHANGELOG.md
   assert_failure

--- a/test/verifyChangesetCategoryPrefixes.bats
+++ b/test/verifyChangesetCategoryPrefixes.bats
@@ -66,6 +66,22 @@ EOF
   assert_success
 }
 
+@test "verifyChangesetCategoryPrefixes fails on lowercase summary after prefix" {
+  cd "$BATS_TEST_TMPDIR" || exit 1
+  mkdir -p .changeset
+  cat >.changeset/bad.md <<'EOF'
+---
+"@t/pkg": patch
+---
+Other: upgrade CI to the latest orb
+EOF
+
+  run node "$VERIFY" .changeset/bad.md
+  assert_failure
+  run grep -F "must be capitalized" <<<"$output"
+  assert_success
+}
+
 @test "embedded category prefix scripts match source modules" {
   local embedded_prefixes embedded_verify expected_prefixes expected_verify
   embedded_prefixes="$(python3 -c "


### PR DESCRIPTION
## Summary
- Enforce sentence case after category prefixes in `verify-changesets` so stripped changelog bullets stay capitalized (e.g. `Other: Upgrade…`, not `Other: upgrade…`).
- Document the rule in the org changeset/review skills and sync stage-script embeddings.
- Add bats coverage for lowercase rejection and non-letter summary starts.

## Test plan
- [x] `pnpm exec bats test/changesetCategoryPrefixes.bats test/verifyChangesetCategoryPrefixes.bats test/rewriteChangelogCategories.bats test/formatChangesetsBatchReleaseNotes.bats test/formatChangesetsBatchReleaseNotesEmbedding.bats test/stageReleaseCycleWriterEmbedding.bats test/runVerifyChangesets.bats`
- [x] Pre-commit lint (`pnpm lint`) passed on commit
- [ ] CI green on the PR


Made with [Cursor](https://cursor.com)