### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.24.2)

### DIFF
--- a/.changeset/drop-dependency-bump-changelog-bullets.md
+++ b/.changeset/drop-dependency-bump-changelog-bullets.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: Drop Changesets dependency-bump changelog bullets (`Updated dependencies` and bare `pkg@version`) during category rewrite so `promote-prod-release` no longer fails on internal workspace bumps.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chiubaka/circleci-orb
 
+## 0.24.2
+
+### Bug Fixes
+
+- Drop Changesets dependency-bump changelog bullets (`Updated dependencies` and bare `pkg@version`) during category rewrite so `promote-prod-release` no longer fails on internal workspace bumps.
+
 ## 0.24.1
 
 ### Improvements

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### @chiubaka/circleci-orb

#### Bug Fixes

- Drop Changesets dependency-bump changelog bullets (`Updated dependencies` and bare `pkg@version`) during category rewrite so `promote-prod-release` no longer fails on internal workspace bumps.

## Published versions

- `@chiubaka/circleci-orb@0.24.2`
