### PR TITLE
fix(release): configure git identity for promote-prod-release

### DIFF
--- a/.changeset/promote-prod-release-git-identity.md
+++ b/.changeset/promote-prod-release-git-identity.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": patch
+---
+
+Fix: Configure git user identity in `promote-prod-release` so finalize commits and annotated prod tags succeed on CircleCI Docker executors without a consumer pre-step.

--- a/src/jobs/promote-prod-release.yml
+++ b/src/jobs/promote-prod-release.yml
@@ -106,7 +106,12 @@ steps:
         - run:
             name: Configure git user
             working_directory: << parameters.app-dir >>
-            command: git config --global user.name << parameters.git-user-name >> && git config --global user.email << parameters.git-user-email >>
+            environment:
+              GIT_USER_NAME: << parameters.git-user-name >>
+              GIT_USER_EMAIL: << parameters.git-user-email >>
+            command: |
+              git config --global user.name "$GIT_USER_NAME"
+              git config --global user.email "$GIT_USER_EMAIL"
   - promote-prod-release:
       app-dir: << parameters.app-dir >>
       primary-branch: << parameters.primary-branch >>

--- a/src/jobs/promote-prod-release.yml
+++ b/src/jobs/promote-prod-release.yml
@@ -14,9 +14,23 @@ parameters:
   primary-branch:
     type: string
     default: "master"
+  configure-git-user:
+    type: boolean
+    default: true
+    description: >
+      Configure global git user before finalize commit and annotated prod tag.
+      CircleCI Docker executors have no default identity.
   create-github-release:
     type: boolean
     default: true
+  git-user-email:
+    type: string
+    default: circleci@chiubaka.com
+    description: Git user email when configure-git-user is true.
+  git-user-name:
+    type: string
+    default: CircleCI
+    description: Git user name when configure-git-user is true.
   on-existing-tag:
     type: enum
     enum:
@@ -86,6 +100,13 @@ steps:
       checkout: true
       primary-branch: << parameters.primary-branch >>
       skip-pnpm-install: << parameters.skip-install >>
+  - when:
+      condition: << parameters.configure-git-user >>
+      steps:
+        - run:
+            name: Configure git user
+            working_directory: << parameters.app-dir >>
+            command: git config --global user.name << parameters.git-user-name >> && git config --global user.email << parameters.git-user-email >>
   - promote-prod-release:
       app-dir: << parameters.app-dir >>
       primary-branch: << parameters.primary-branch >>

--- a/src/scripts/runPromoteProdRelease.sh
+++ b/src/scripts/runPromoteProdRelease.sh
@@ -180,6 +180,18 @@ _resolve_tag_sha() {
   esac
 }
 
+# Finalize commit and annotated prod tags need identity. The promote-prod-release
+# job configures this via configure-git-user; fail early when callers skip that step.
+_require_git_identity() {
+  local name email
+  name=$(git config user.name 2>/dev/null || true)
+  email=$(git config user.email 2>/dev/null || true)
+  if [[ -z "$name" || -z "$email" ]]; then
+    echo "runPromoteProdRelease: git user.name and user.email must be set before the finalize commit or annotated prod tag (enable the job configure-git-user step, or set git-user-name / git-user-email)." >&2
+    return 1
+  fi
+}
+
 run_promote_prod_release_main() {
   local app_dir releases_dir cycle_dir finalize_script notes_path primary auth_header push_url repo_slug u r
   local target_ref validated_sha finalize_sha tag_sha tag remote_sha on_existing
@@ -241,6 +253,9 @@ run_promote_prod_release_main() {
   if git diff --cached --quiet; then
     echo "runPromoteProdRelease: cycle already finalized on ${target_ref}; continuing."
   else
+    if ! _require_git_identity; then
+      exit 1
+    fi
     git commit --no-verify -m "chore(release): finalize ${CYCLE_ID} for production"
     finalize_sha=$(git rev-parse HEAD)
   fi
@@ -286,6 +301,9 @@ run_promote_prod_release_main() {
       exit 1
     fi
   else
+    if ! _require_git_identity; then
+      exit 1
+    fi
     git -c tag.gpgSign=false tag -fa "$tag" -m "promotion: ${tag}" "$tag_sha"
     git -c "http.https://github.com/.extraheader=AUTHORIZATION: basic ${auth_header}" \
       push "$push_url" "refs/tags/${tag}"

--- a/test/promoteProdReleaseGitIdentity.bats
+++ b/test/promoteProdReleaseGitIdentity.bats
@@ -85,13 +85,18 @@ if not (setup_at < configure_at < promote_at):
 if "condition: << parameters.configure-git-user >>" not in body:
     print("missing when condition on configure-git-user")
     sys.exit(1)
-cmd = (
-    "git config --global user.name << parameters.git-user-name >> "
-    "&& git config --global user.email << parameters.git-user-email >>"
-)
-if cmd not in body:
-    print("missing configure-git-user command matching sibling jobs")
-    sys.exit(1)
+# Pass identity through run-step env and quote at the shell so names with
+# spaces / metacharacters are not word-split (safer than sibling inline expand).
+required = [
+    "GIT_USER_NAME: << parameters.git-user-name >>",
+    "GIT_USER_EMAIL: << parameters.git-user-email >>",
+    'git config --global user.name "$GIT_USER_NAME"',
+    'git config --global user.email "$GIT_USER_EMAIL"',
+]
+for needle in required:
+    if needle not in body:
+        print(f"missing configure-git-user fragment: {needle}")
+        sys.exit(1)
 PY
   assert_success
 }

--- a/test/promoteProdReleaseGitIdentity.bats
+++ b/test/promoteProdReleaseGitIdentity.bats
@@ -1,0 +1,97 @@
+#! /usr/bin/env bats
+# Assert promote-prod-release configures git identity like sibling commit/tag jobs.
+# CircleCI Docker executors have no default user.name / user.email; without this
+# step the finalize commit fails with "Author identity unknown".
+
+setup() {
+  load "helpers/setup"
+  _setup
+}
+
+@test "promote-prod-release job exposes configure-git-user parameters with sibling defaults" {
+  run python3 - "$PROJECT_ROOT/src/jobs/promote-prod-release.yml" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+params = re.search(r"(?ms)^parameters:\n(.*?)(?=^steps:)", text)
+if not params:
+    print("no parameters block")
+    sys.exit(1)
+block = params.group(1)
+
+def param_default(name: str):
+    # Match one parameter stanza; stop before the next top-level param key.
+    m = re.search(
+        rf"(?m)^  {re.escape(name)}:\n((?:    .*\n)*)",
+        block,
+    )
+    if not m:
+        return None
+    dm = re.search(r"(?m)^    default: (.+)$", m.group(1))
+    return dm.group(1).strip() if dm else None
+
+checks = {
+    "configure-git-user": "true",
+    "git-user-name": "CircleCI",
+    "git-user-email": "circleci@chiubaka.com",
+}
+failed = False
+for name, expected in checks.items():
+    actual = param_default(name)
+    if actual != expected:
+        print(f"{name}: expected default {expected!r}, got {actual!r}")
+        failed = True
+sys.exit(1 if failed else 0)
+PY
+  assert_success
+}
+
+@test "promote-prod-release job configures git user after setup and before promote command" {
+  run python3 - "$PROJECT_ROOT/src/jobs/promote-prod-release.yml" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+text = Path(sys.argv[1]).read_text()
+steps = re.search(r"(?ms)^steps:\n(.*)\Z", text)
+if not steps:
+    print("no steps block")
+    sys.exit(1)
+body = steps.group(1)
+
+setup_at = body.find("- setup:")
+configure_at = body.find("name: Configure git user")
+promote_at = body.find("- promote-prod-release:")
+
+if setup_at < 0:
+    print("missing setup step")
+    sys.exit(1)
+if configure_at < 0:
+    print("missing Configure git user step")
+    sys.exit(1)
+if promote_at < 0:
+    print("missing promote-prod-release command step")
+    sys.exit(1)
+if not (setup_at < configure_at < promote_at):
+    print(
+        f"expected setup < configure < promote; got "
+        f"setup={setup_at}, configure={configure_at}, promote={promote_at}"
+    )
+    sys.exit(1)
+
+# Conditional when + defaults matching sibling jobs.
+if "condition: << parameters.configure-git-user >>" not in body:
+    print("missing when condition on configure-git-user")
+    sys.exit(1)
+cmd = (
+    "git config --global user.name << parameters.git-user-name >> "
+    "&& git config --global user.email << parameters.git-user-email >>"
+)
+if cmd not in body:
+    print("missing configure-git-user command matching sibling jobs")
+    sys.exit(1)
+PY
+  assert_success
+}

--- a/test/runPromoteProdRelease.bats
+++ b/test/runPromoteProdRelease.bats
@@ -14,6 +14,9 @@ _promote_prod_init_clone() {
   git init --bare "$bare" >/dev/null 2>&1
   mkdir -p "$clone"
   git -C "$clone" init >/dev/null 2>&1
+  # Mirrors the job's "Configure git user" step (CircleCI Docker has no defaults).
+  # Production identity comes from promote-prod-release.yml; tests set local config
+  # so script coverage does not depend on the developer's ambient git identity.
   git -C "$clone" config user.email test@test
   git -C "$clone" config user.name Test
   bare_abs=$(cd "$(dirname "$bare")" && pwd)/$(basename "$bare")
@@ -59,6 +62,26 @@ _run_promote_prod_release() {
     PATH="${bindir}:$PATH" \
     "$@" \
     bash "$PROJECT_ROOT/src/scripts/runPromoteProdRelease.sh"
+}
+
+@test "fails early with clear message when git identity is missing" {
+  local clone bindir gh_call_log
+  clone=$(_promote_prod_init_clone)
+  bindir=$(_write_gh_stub)
+  gh_call_log=$(mktemp)
+  cd "$clone" || exit 1
+  git config --unset-all user.name || true
+  git config --unset-all user.email || true
+  # Isolate from ambient global identity (CI images have none; local may differ).
+  export GIT_CONFIG_GLOBAL=/dev/null
+  export GIT_CONFIG_SYSTEM=/dev/null
+
+  _run_promote_prod_release "$bindir" "$gh_call_log"
+
+  assert_failure
+  assert_output --partial "user.name"
+  assert_output --partial "user.email"
+  refute_output --partial "Author identity unknown"
 }
 
 @test "default finalize mode tags prod release at finalize commit" {


### PR DESCRIPTION
## Summary
- Add `configure-git-user` / `git-user-name` / `git-user-email` to `promote-prod-release` (defaults matching sibling jobs: `CircleCI` / `circleci@chiubaka.com`) and run the same conditional Configure git user step after `setup`.
- Harden `runPromoteProdRelease.sh` to fail early with a clear message when identity is missing before the finalize commit or annotated `prod-<cycle-id>` tag.
- Add bats coverage for the job YAML step and for the script’s missing-identity path; document that fixture clones mirror the job’s git-user step.

Fixes consumers on `@0.24.2` dying with `Author identity unknown` on the local finalize `git commit` in CircleCI Docker executors. Patch release via changeset → `0.24.3`.

## Test plan
- [x] `pnpm lint` (shellcheck + yamllint)
- [x] `bats` for `promoteProdReleaseGitIdentity.bats` + `runPromoteProdRelease.bats` (including missing-identity early fail)
- [x] Full `pnpm test` suite
- [ ] After merge/release: consumer bump to `0.24.3` and re-run `promote-prod-release` without a git-config `pre-steps` workaround


Made with [Cursor](https://cursor.com)