### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.24.3)

### DIFF
--- a/.changeset/promote-prod-release-git-identity.md
+++ b/.changeset/promote-prod-release-git-identity.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": patch
----
-
-Fix: Configure git user identity in `promote-prod-release` so finalize commits and annotated prod tags succeed on CircleCI Docker executors without a consumer pre-step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @chiubaka/circleci-orb
 
+## 0.24.3
+
+### Bug Fixes
+
+- Configure git user identity in `promote-prod-release` so finalize commits and annotated prod tags succeed on CircleCI Docker executors without a consumer pre-step.
+
 ## 0.24.2
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### @chiubaka/circleci-orb

#### Bug Fixes

- Configure git user identity in `promote-prod-release` so finalize commits and annotated prod tags succeed on CircleCI Docker executors without a consumer pre-step.

## Published versions

- `@chiubaka/circleci-orb@0.24.3`
