### PR TITLE
feat(release): collate cycle release notes without RC headings

### DIFF
--- a/.changeset/collate-cycle-release-notes.md
+++ b/.changeset/collate-cycle-release-notes.md
@@ -1,0 +1,5 @@
+---
+"@chiubaka/circleci-orb": minor
+---
+
+Feature: Collate multi-RC cycle release notes into one package-then-category changelog without RC section headings

--- a/org/docs/adr/0041-release-train-review-artifacts-for-deployable-applications.md
+++ b/org/docs/adr/0041-release-train-review-artifacts-for-deployable-applications.md
@@ -1,6 +1,6 @@
 ---
 status: accepted
-date: 2026-07-07
+date: 2026-08-08
 decision-makers: Daniel Chiu
 ---
 
@@ -71,7 +71,7 @@ Every release cycle uses a directory ([ADR 0042](0042-release-cycles-rc-identifi
 1. Format the **newly written top version block** from each affected deployable `CHANGELOG.md` (same batch formatter as release-PR bodies).
 2. Write **`rc<n>/release-notes.md`** for that cut only (overwrite on re-run of the same RC is forbidden; each RC directory is created once).
 3. Update **`rc<n>/manifest.yml`** pins and **`cutAt`** (ISO-8601 UTC) for that cut.
-4. Refresh the cycle-level **`release-notes.md`** as a rollup of all `rc*/release-notes.md` in order. Section headings in the rollup MUST use the full **RC promotion id** (`<cycle-id>-rc<n>`, for example `2026.07.01.1-rc1`), not bare `rc1` / `rc2`. Production finalization regenerates the same rollup after any stable-version ceremony.
+4. Refresh the cycle-level **`release-notes.md`** as a **collated** rollup of all `rc*/release-notes.md` files in cut order. The rollup MUST merge bullets across cuts into the same nesting used for batch release notes (default **package-then-category**: publishable package, then change category). It MUST **not** emit RC promotion headings (`<cycle-id>-rc<n>`) or otherwise structure Artifact 3 as a per-candidate changelog. Per-cut detail remains in `rc<n>/release-notes.md`. Production finalization regenerates the same collated rollup after any stable-version ceremony.
 
 All notes files are **tooling-owned**; do not hand-edit ([agents/skills/changesets-hygiene/SKILL.md](../../agents/skills/changesets-hygiene/SKILL.md)).
 
@@ -87,7 +87,7 @@ All notes files are **tooling-owned**; do not hand-edit ([agents/skills/changese
 
 **Artifact 2:** Applies when a cycle has more than one cut—typically staging soak (topologies A, B). Each cut gets its own `rc<n>/release-notes.md`. Optional CI SHOULD surface the latest RC notes when deploying `staging-<cycle-id>-rc<n>`.
 
-**Artifact 3:** Cycle-level `release-notes.md` concatenates (or regenerates from) all `rc*/release-notes.md` in order, with each section headed by the full RC promotion id (`<cycle-id>-rc<n>`). It is **refreshed on every RC cut** so reviewers can read the full cycle story during soak. Published at **`prod-<cycle-id>`** as the GitHub Release body. The GitHub Release title uses the cycle id only (no `-rc` suffix) ([ADR 0042](0042-release-cycles-rc-identifiers-and-manifest-directories.md)).
+**Artifact 3:** Cycle-level `release-notes.md` **collates** all `rc*/release-notes.md` content into a single changelog—grouped like other release notes (default package-then-category)—**without** RC promotion section headings. It is **refreshed on every RC cut** so reviewers can read the full cycle story during soak. Published at **`prod-<cycle-id>`** as the GitHub Release body. The GitHub Release title uses the cycle id only (no `-rc` suffix) ([ADR 0042](0042-release-cycles-rc-identifiers-and-manifest-directories.md)).
 
 ### Publication timing
 
@@ -105,14 +105,14 @@ Review artifacts and on-disk layout are **the same** across supported topologies
 | **B — Staging + prod**       | No deployed dev; same staging RC flow as A         | Yes, when soak adds rc2+        |
 | **C — Dev + prod**           | Dev continuous; gated prod; often single `rc1` cut | Rare (second pre-prod cut only) |
 
-Topology **C** still uses `rc1/` and `release-notes.md` with heading `## <cycle-id>-rc1`; it does not require staging promotion tags.
+Topology **C** still uses `rc1/` and a collated cycle `release-notes.md` (for a single cut, equivalent to reformatting that cut’s notes without an RC heading); it does not require staging promotion tags.
 
 ### Soak iteration rules
 
 1. Fixes merge with new `.changeset/` entries.
 2. Patch **release PR** adds **`rc<n+1>/`** under the **same** cycle id ([ADR 0042](0042-release-cycles-rc-identifiers-and-manifest-directories.md)); do not allocate a new cycle id. The workspace remains in Changesets prerelease mode ([ADR 0043](0043-prerelease-until-production-for-application-release-cycles.md)).
 3. Promote staging with `staging-<cycle-id>-rc<n+1>` (prerelease artifact pins).
-4. Prod finalization exits prerelease, cuts stable semver, refreshes the highest RC manifest pins, then promotes **`prod-<cycle-id>`**; `release-notes.md` includes all RCs.
+4. Prod finalization exits prerelease, cuts stable semver, refreshes the highest RC manifest pins, then promotes **`prod-<cycle-id>`**; `release-notes.md` is the collated full-cycle changelog (not a per-RC concatenation).
 
 ### Hotfix releases
 
@@ -122,7 +122,7 @@ Production hotfixes are **new release cycles**, not soak iterations ([ADR 0042 �
 | ------------------------------------------- | --------------------------------------------------------------------------------- |
 | **1** (`rc1/release-notes.md`)                      | Hotfix-only batch since last prod (release PR body mirrors this)                  |
 | **2**                                       | Typically absent (single `rc1` cut)                                               |
-| **3** (`release-notes.md` → GitHub Release) | Full hotfix cycle at `prod-<new-cycle-id>`; often one section `## <cycle-id>-rc1` |
+| **3** (`release-notes.md` → GitHub Release) | Full hotfix cycle at `prod-<new-cycle-id>`; collated notes (often a single cut’s content) |
 
 Staging promotion for hotfixes is optional per repository policy; canonical GitHub Release timing and `promotedAt` rules are unchanged.
 
@@ -186,18 +186,18 @@ At production finalization, tooling refreshes this highest RC manifest to **stab
 **`release-notes.md`** (artifact 3 — excerpt; present after rc2 cut):
 
 ```markdown
-## 2026.07.01.1-rc1
+### @chiubaka/server
 
-### Features
+#### Features
 
-…
+- …
 
-## 2026.07.01.1-rc2
+#### Bug Fixes
 
-### Bug Fixes
-
-…
+- Fix null handling when export queue is empty
 ```
+
+RC promotion headings are intentionally omitted; reviewers use `rc1/release-notes.md` / `rc2/release-notes.md` for per-cut diffs.
 
 **Promotion tags:** `staging-2026.07.01.1-rc1`, `staging-2026.07.01.1-rc2`, `prod-2026.07.01.1`.
 

--- a/org/docs/adr/0042-release-cycles-rc-identifiers-and-manifest-directories.md
+++ b/org/docs/adr/0042-release-cycles-rc-identifiers-and-manifest-directories.md
@@ -160,7 +160,7 @@ artifacts:
 
 **Deploy resolution:** coordinated deploy for promotion tag `staging-2026.07.01.1-rc2` reads `.releases/2026.07.01.1/rc2/manifest.yml`. For `prod-2026.07.01.1`, automation MUST use the **highest-numbered `rc*/manifest.yml` present on the tagged commit** (the validated final RC).
 
-**`release-notes.md`:** tooling-generated rollup of all `rc*/release-notes.md` in order; refreshed on every RC cut and used as the canonical GitHub Release body at prod ([ADR 0041](0041-release-train-review-artifacts-for-deployable-applications.md)). Each rollup section MUST be headed with the full RC promotion id (`<cycle-id>-rc<n>`, for example `## 2026.07.01.1-rc1`), matching staging promotion tag stems. Per-RC `rc<n>/release-notes.md` files contain only that cut’s formatted batch (no section heading required in the leaf file). For a single-cut cycle, the rollup MAY contain one section (`<cycle-id>-rc1`) identical in body to `rc1/release-notes.md`.
+**`release-notes.md`:** tooling-generated **collated** rollup of all `rc*/release-notes.md` files; refreshed on every RC cut and used as the canonical GitHub Release body at prod ([ADR 0041](0041-release-train-review-artifacts-for-deployable-applications.md)). The rollup merges cuts into one changelog with the same nesting as batch release notes (default package-then-category) and MUST **not** use RC promotion headings (`## <cycle-id>-rc<n>`). Per-RC `rc<n>/release-notes.md` files contain only that cut’s formatted batch. For a single-cut cycle, the rollup body matches a re-nested form of `rc1/release-notes.md`.
 
 ### Single-cut cycles (topology C and simple paths)
 

--- a/org/docs/adr/0043-prerelease-until-production-for-application-release-cycles.md
+++ b/org/docs/adr/0043-prerelease-until-production-for-application-release-cycles.md
@@ -78,7 +78,7 @@ Consequences for hybrids:
 ### Relationship to release-cycle and review-artifact ADRs
 
 - An **RC** remains one version cut and pin set within a cycle ([ADR 0042](0042-release-cycles-rc-identifiers-and-manifest-directories.md)), but for normal cycles that cut yields **prerelease** package semver until production finalization.
-- Per-RC `notes.md` still snapshots the batch at each cut; production `release-notes.md` remains the rollup published at `prod-<cycle-id>` ([ADR 0041](0041-release-train-review-artifacts-for-deployable-applications.md)). Stable changelog sections produced at pre-exit belong with the production finalize commit and MUST be reflected in the production review story (rollup and/or highest-RC notes refresh as implemented by tooling).
+- Per-RC `notes.md` still snapshots the batch at each cut; production `release-notes.md` remains the **collated** cycle rollup published at `prod-<cycle-id>` ([ADR 0041](0041-release-train-review-artifacts-for-deployable-applications.md)). Stable changelog sections produced at pre-exit belong with the production finalize commit and MUST be reflected in the production review story (collated rollup and/or highest-RC notes refresh as implemented by tooling).
 
 ### Consequences
 

--- a/org/docs/adr/0043-prerelease-until-production-for-application-release-cycles.md
+++ b/org/docs/adr/0043-prerelease-until-production-for-application-release-cycles.md
@@ -78,7 +78,7 @@ Consequences for hybrids:
 ### Relationship to release-cycle and review-artifact ADRs
 
 - An **RC** remains one version cut and pin set within a cycle ([ADR 0042](0042-release-cycles-rc-identifiers-and-manifest-directories.md)), but for normal cycles that cut yields **prerelease** package semver until production finalization.
-- Per-RC `notes.md` still snapshots the batch at each cut; production `release-notes.md` remains the **collated** cycle rollup published at `prod-<cycle-id>` ([ADR 0041](0041-release-train-review-artifacts-for-deployable-applications.md)). Stable changelog sections produced at pre-exit belong with the production finalize commit and MUST be reflected in the production review story (collated rollup and/or highest-RC notes refresh as implemented by tooling).
+- Per-RC `rc<n>/release-notes.md` still snapshots the batch at each cut; production `release-notes.md` remains the **collated** cycle rollup published at `prod-<cycle-id>` ([ADR 0041](0041-release-train-review-artifacts-for-deployable-applications.md)). Stable changelog sections produced at pre-exit belong with the production finalize commit and MUST be reflected in the production review story (collated rollup and/or highest-RC notes refresh as implemented by tooling).
 
 ### Consequences
 

--- a/org/docs/adr/examples/release-train-review-artifacts.md
+++ b/org/docs/adr/examples/release-train-review-artifacts.md
@@ -22,7 +22,7 @@ Illustrative walkthrough for a three-environment application monorepo. Not norma
      rc1/release-notes.md
    ```
 
-3. Release PR body shows the rc1 batch (**artifact 1**); cycle `release-notes.md` already holds the rollup section for rc1.
+3. Release PR body shows the rc1 batch (**artifact 1**); cycle `release-notes.md` already holds the collated full-cycle notes (rc1 only at this point).
 4. Merge → gated publish (prerelease artifact tags) → `staging-2026.07.01.1-rc1` → staging deploy.
 
 ## rc2 — soak patch (2026-07-03)
@@ -56,7 +56,7 @@ Same directory layout and prerelease-at-rc1 rule. Only `rc1/` before prod; if no
   cycle.yml
   rc1/manifest.yml
   rc1/release-notes.md
-  release-notes.md   # single section ## 2026.07.01.1-rc1
+  release-notes.md   # collated cycle notes (no ## <cycle-id>-rc1 heading)
 ```
 
 Promotion: `prod-2026.07.01.1` after finalize (no staging promotion tags).

--- a/src/scripts/rollupReleaseNotes.mjs
+++ b/src/scripts/rollupReleaseNotes.mjs
@@ -13,6 +13,8 @@
  *   RELEASE_NOTES_GROUPING — category | bump-type (default category)
  *   RELEASE_NOTES_NESTING — package-then-category | category-then-package
  *   CHANGESET_CATEGORY_PREFIXES_SCRIPT — optional override for prefixes module
+ *   ROLLUP_ALLOW_UNPARSED_RELEASE_NOTES — when "true", warn on unparsed lines
+ *     instead of failing (default: fail)
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -46,15 +48,13 @@ async function loadCategoryPrefixes() {
   return import(pathToFileURL(path.join(SCRIPT_DIR, "changesetCategoryPrefixes.mjs")).href);
 }
 
-function classifyCategoryHeading(line) {
+function classifyCategoryHeading(line, titles) {
   const t = String(line).trim().replace(/^#{1,6}\s+/, "");
-  if (/^Breaking(?:\s+Changes)?$/i.test(t)) return "breaking";
-  if (/^Security$/i.test(t)) return "security";
-  if (/^Features?$/i.test(t)) return "features";
-  if (/^Improvements?$/i.test(t)) return "improvements";
-  if (/^(?:Bug\s+)?Fix(?:es)?$/i.test(t)) return "bugfixes";
-  if (/^Deprecations?$/i.test(t)) return "deprecations";
-  if (/^Other(?:\s+Changes)?$/i.test(t)) return "other";
+  const normalized = t.toLowerCase();
+  for (const [key, title] of Object.entries(titles ?? {})) {
+    const bare = String(title).replace(/^#+\s*/, "").trim().toLowerCase();
+    if (normalized === bare) return key;
+  }
   return null;
 }
 
@@ -62,6 +62,11 @@ function classifyBumpHeading(line) {
   const t = String(line).trim().replace(/^#{1,6}\s+/, "");
   const m = t.match(/^(Major|Minor|Patch)(?:\s+Changes)?$/i);
   return m ? m[1].toLowerCase() : null;
+}
+
+function classifySectionHeading(line, grouping, titles) {
+  if (grouping === "bump-type") return classifyBumpHeading(line);
+  return classifyCategoryHeading(line, titles);
 }
 
 function headingLevel(line) {
@@ -108,9 +113,14 @@ function stripListMarker(line) {
 
 function splitTopLevelBulletBlocks(lines) {
   const blocks = [];
+  /** @type {number[]} */
+  const consumedOffsets = [];
   let i = 0;
   while (i < lines.length) {
-    while (i < lines.length && String(lines[i]).trim() === "") i += 1;
+    while (i < lines.length && String(lines[i]).trim() === "") {
+      consumedOffsets.push(i);
+      i += 1;
+    }
     if (i >= lines.length) break;
     if (!isTopLevelBullet(lines[i])) {
       i += 1;
@@ -123,18 +133,24 @@ function splitTopLevelBulletBlocks(lines) {
       if (isTopLevelBullet(line) && block.length > 0) break;
       if (block.length === 0 && !isTopLevelBullet(line)) break;
       block.push(line);
+      consumedOffsets.push(i);
       i += 1;
     }
     if (block.length > 0) blocks.push(block);
   }
-  return blocks;
+  return { blocks, consumedOffsets };
 }
 
 function splitIndentedBulletBlocks(lines) {
   const blocks = [];
+  /** @type {number[]} */
+  const consumedOffsets = [];
   let i = 0;
   while (i < lines.length) {
-    while (i < lines.length && String(lines[i]).trim() === "") i += 1;
+    while (i < lines.length && String(lines[i]).trim() === "") {
+      consumedOffsets.push(i);
+      i += 1;
+    }
     if (i >= lines.length) break;
     if (!isIndentedBullet(lines[i])) {
       i += 1;
@@ -148,6 +164,7 @@ function splitIndentedBulletBlocks(lines) {
       if (block.length === 0 && !isIndentedBullet(line)) break;
       if (isTopLevelBullet(line)) break;
       block.push(line);
+      consumedOffsets.push(i);
       i += 1;
     }
     if (block.length > 0) {
@@ -159,7 +176,7 @@ function splitIndentedBulletBlocks(lines) {
       blocks.push(normalized);
     }
   }
-  return blocks;
+  return { blocks, consumedOffsets };
 }
 
 function bulletKey(block) {
@@ -177,46 +194,58 @@ function appendUniqueBlocks(target, blocks) {
   }
 }
 
-function classifySectionHeading(line, grouping) {
-  if (grouping === "bump-type") return classifyBumpHeading(line);
-  return classifyCategoryHeading(line);
-}
-
 /**
  * Parse one RC notes file into package buckets + published versions.
  * Accepts both package-then-category and category-then-package layouts.
+ * @returns {{ packages: Map<string, {name: string, buckets: Record<string, string[][]>}>, published: string[], unparsed: {line: number, text: string}[] }}
  */
-function parseRcNotes(content, order, grouping) {
+function parseRcNotes(content, order, grouping, titles) {
   const packages = new Map();
   const published = [];
+  /** @type {Set<number>} */
+  const consumed = new Set();
+  const mark = (...idxs) => {
+    for (const idx of idxs) {
+      if (typeof idx === "number" && idx >= 0) consumed.add(idx);
+    }
+  };
+  const markOffsets = (base, offsets) => {
+    for (const offset of offsets) mark(base + offset);
+  };
+
   if (isEmptyNotesPlaceholder(content)) {
-    return { packages, published };
+    return { packages, published, unparsed: [] };
   }
 
   const lines = content.replace(/\r\n/g, "\n").split("\n");
   let i = 0;
   let currentPackage = null;
-  let currentCategory = null;
 
-  const flushCategoryBlocks = (pkgName, cat, segmentLines) => {
+  const flushCategoryBlocks = (pkgName, cat, segmentStart, segmentLines) => {
     if (!pkgName || !cat || !order.includes(cat)) return;
     const pkg = ensurePackage(packages, pkgName, order);
-    const blocks = splitTopLevelBulletBlocks(segmentLines);
+    const { blocks, consumedOffsets } = splitTopLevelBulletBlocks(segmentLines);
     appendUniqueBlocks(pkg.buckets[cat], blocks);
+    markOffsets(segmentStart, consumedOffsets);
   };
 
-  const flushNestedPackageBlocks = (cat, segmentLines) => {
+  const flushNestedPackageBlocks = (cat, segmentStart, segmentLines) => {
     if (!cat || !order.includes(cat)) return;
     let j = 0;
     while (j < segmentLines.length) {
-      while (j < segmentLines.length && String(segmentLines[j]).trim() === "") j += 1;
+      while (j < segmentLines.length && String(segmentLines[j]).trim() === "") {
+        mark(segmentStart + j);
+        j += 1;
+      }
       if (j >= segmentLines.length) break;
       const pkgName = packageBulletName(segmentLines[j]);
       if (!pkgName) {
         j += 1;
         continue;
       }
+      mark(segmentStart + j);
       j += 1;
+      const nestedStart = j;
       const nested = [];
       while (j < segmentLines.length) {
         const line = segmentLines[j];
@@ -226,7 +255,9 @@ function parseRcNotes(content, order, grouping) {
         j += 1;
       }
       const pkg = ensurePackage(packages, pkgName, order);
-      appendUniqueBlocks(pkg.buckets[cat], splitIndentedBulletBlocks(nested));
+      const { blocks, consumedOffsets } = splitIndentedBulletBlocks(nested);
+      appendUniqueBlocks(pkg.buckets[cat], blocks);
+      markOffsets(segmentStart + nestedStart, consumedOffsets);
     }
   };
 
@@ -235,28 +266,34 @@ function parseRcNotes(content, order, grouping) {
     const level = headingLevel(line);
 
     if (isPublishedVersionsHeading(line)) {
+      mark(i);
       i += 1;
       while (i < lines.length && headingLevel(lines[i]) === 0) {
         const m = String(lines[i]).match(/^[-*]\s+`([^`]+)`\s*$/);
-        if (m) published.push(m[1]);
+        if (m) {
+          published.push(m[1]);
+          mark(i);
+        } else if (String(lines[i]).trim() === "") {
+          mark(i);
+        }
         i += 1;
       }
       continue;
     }
 
     if (level >= 2 && /^##\s+\S/.test(line) && !isPublishedVersionsHeading(line)) {
-      // Skip stray ## headings (e.g. legacy RC ids if re-rolled).
+      // Leave unrecognized ## sections unparsed (including following body).
       i += 1;
       continue;
     }
 
     if (level === 3 || level === 4) {
-      const section = classifySectionHeading(line, grouping);
+      const section = classifySectionHeading(line, grouping, titles);
       if (section) {
         if (level === 3 && currentPackage === null) {
-          // category-then-package: ### Category
-          currentCategory = section;
+          mark(i);
           i += 1;
+          const segmentStart = i;
           const segment = [];
           while (i < lines.length) {
             const lvl = headingLevel(lines[i]);
@@ -265,14 +302,13 @@ function parseRcNotes(content, order, grouping) {
             segment.push(lines[i]);
             i += 1;
           }
-          flushNestedPackageBlocks(currentCategory, segment);
-          currentCategory = null;
+          flushNestedPackageBlocks(section, segmentStart, segment);
           continue;
         }
         if (currentPackage !== null) {
-          // package-then-category: #### Category under ### package
-          currentCategory = section;
+          mark(i);
           i += 1;
+          const segmentStart = i;
           const segment = [];
           while (i < lines.length) {
             const lvl = headingLevel(lines[i]);
@@ -281,25 +317,33 @@ function parseRcNotes(content, order, grouping) {
             segment.push(lines[i]);
             i += 1;
           }
-          flushCategoryBlocks(currentPackage, currentCategory, segment);
-          currentCategory = null;
+          flushCategoryBlocks(currentPackage, section, segmentStart, segment);
           continue;
         }
       }
 
       if (level === 3 && !section) {
-        // package-then-category: ### @scope/name
         currentPackage = String(line).replace(/^###\s+/, "").trim();
-        currentCategory = null;
+        mark(i);
         i += 1;
         continue;
       }
     }
 
+    if (String(line).trim() === "") {
+      mark(i);
+    }
     i += 1;
   }
 
-  return { packages, published };
+  const unparsed = [];
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    if (consumed.has(idx)) continue;
+    if (String(lines[idx]).trim() === "") continue;
+    unparsed.push({ line: idx + 1, text: lines[idx] });
+  }
+
+  return { packages, published, unparsed };
 }
 
 function demoteHeading(title) {
@@ -429,10 +473,16 @@ async function main() {
 
   const merged = new Map();
   let published = [];
+  const allowUnparsed =
+    String(process.env.ROLLUP_ALLOW_UNPARSED_RELEASE_NOTES || "")
+      .trim()
+      .toLowerCase() === "true";
+  /** @type {{ path: string, line: number, text: string }[]} */
+  const unparsedAll = [];
 
   for (const { notesPath } of rcNotes) {
     const body = fs.readFileSync(notesPath, "utf8");
-    const parsed = parseRcNotes(body, order, GROUPING);
+    const parsed = parseRcNotes(body, order, GROUPING, titles);
     for (const [name, pkg] of parsed.packages) {
       const target = ensurePackage(merged, name, order);
       for (const cat of order) {
@@ -440,6 +490,26 @@ async function main() {
       }
     }
     published = mergePublishedVersions(published, parsed.published);
+    for (const entry of parsed.unparsed) {
+      unparsedAll.push({ path: notesPath, ...entry });
+    }
+  }
+
+  if (unparsedAll.length > 0) {
+    const samples = unparsedAll
+      .slice(0, 5)
+      .map((entry) => `${entry.path}:${entry.line}: ${entry.text.trim()}`)
+      .join("\n");
+    const detail =
+      `unparsed ${unparsedAll.length} line(s) in rc release-notes ` +
+      `(would be omitted from cycle Artifact 3). Examples:\n${samples}`;
+    if (allowUnparsed) {
+      process.stderr.write(`rollupReleaseNotes: warning: ${detail}\n`);
+    } else {
+      fail(
+        `${detail}\nSet ROLLUP_ALLOW_UNPARSED_RELEASE_NOTES=true to warn instead of fail.`,
+      );
+    }
   }
 
   const lines =

--- a/src/scripts/rollupReleaseNotes.mjs
+++ b/src/scripts/rollupReleaseNotes.mjs
@@ -1,22 +1,411 @@
 #!/usr/bin/env node
 /**
- * Roll up per-RC release-notes.md into cycle release-notes.md (ADR 0041).
+ * Collate per-RC release-notes.md into cycle release-notes.md (ADR 0041).
+ *
+ * Merges all `rc<n>/release-notes.md` files into one document with the same
+ * nesting as formatChangesetsBatchReleaseNotes (default: package-then-category).
+ * Does not emit RC promotion headings — Artifact 3 is the full-cycle story
+ * without referencing soak candidates.
+ *
  * Usage: node rollupReleaseNotes.mjs <cycle-dir> [outfile]
+ *
+ * Env:
+ *   RELEASE_NOTES_GROUPING — category | bump-type (default category)
+ *   RELEASE_NOTES_NESTING — package-then-category | category-then-package
+ *   CHANGESET_CATEGORY_PREFIXES_SCRIPT — optional override for prefixes module
  */
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
 import { listRcNotesPaths } from "./lib/releaseCycle.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+const GROUPING = (process.env.RELEASE_NOTES_GROUPING || "category").toLowerCase();
+const NESTING = (
+  process.env.RELEASE_NOTES_NESTING || "package-then-category"
+).toLowerCase();
+
+const BUMP_TYPE_ORDER = ["major", "minor", "patch"];
+const BUMP_TYPE_TITLES = {
+  major: "### Major Changes",
+  minor: "### Minor Changes",
+  patch: "### Patch Changes",
+};
 
 function fail(msg) {
   process.stderr.write(`rollupReleaseNotes: ${msg}\n`);
   process.exit(1);
 }
 
-function main() {
+async function loadCategoryPrefixes() {
+  const override = process.env.CHANGESET_CATEGORY_PREFIXES_SCRIPT;
+  if (override) {
+    return import(pathToFileURL(path.resolve(override)).href);
+  }
+  return import(pathToFileURL(path.join(SCRIPT_DIR, "changesetCategoryPrefixes.mjs")).href);
+}
+
+function classifyCategoryHeading(line) {
+  const t = String(line).trim().replace(/^#{1,6}\s+/, "");
+  if (/^Breaking(?:\s+Changes)?$/i.test(t)) return "breaking";
+  if (/^Security$/i.test(t)) return "security";
+  if (/^Features?$/i.test(t)) return "features";
+  if (/^Improvements?$/i.test(t)) return "improvements";
+  if (/^(?:Bug\s+)?Fix(?:es)?$/i.test(t)) return "bugfixes";
+  if (/^Deprecations?$/i.test(t)) return "deprecations";
+  if (/^Other(?:\s+Changes)?$/i.test(t)) return "other";
+  return null;
+}
+
+function classifyBumpHeading(line) {
+  const t = String(line).trim().replace(/^#{1,6}\s+/, "");
+  const m = t.match(/^(Major|Minor|Patch)(?:\s+Changes)?$/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function headingLevel(line) {
+  const m = String(line).match(/^(#{1,6})\s+\S/);
+  return m ? m[1].length : 0;
+}
+
+function isPublishedVersionsHeading(line) {
+  return /^##\s+Published versions\s*$/i.test(String(line).trim());
+}
+
+function isEmptyNotesPlaceholder(text) {
+  return /_No CHANGELOG\.md updates in this version cut\._/i.test(text);
+}
+
+function emptyBuckets(order) {
+  return Object.fromEntries(order.map((key) => [key, []]));
+}
+
+function ensurePackage(map, name, order) {
+  if (!map.has(name)) {
+    map.set(name, { name, buckets: emptyBuckets(order) });
+  }
+  return map.get(name);
+}
+
+function isTopLevelBullet(line) {
+  const t = String(line).replace(/\r$/, "");
+  return /^[-*]\s/.test(t) && !/^\s/.test(t);
+}
+
+function isIndentedBullet(line) {
+  return /^\s{2,}[-*]\s/.test(String(line));
+}
+
+function packageBulletName(line) {
+  const m = String(line).match(/^[-*]\s+\*\*(.+?)\*\*\s*$/);
+  return m ? m[1].trim() : null;
+}
+
+function stripListMarker(line) {
+  return String(line).replace(/^\s*[-*]\s+/, "");
+}
+
+function splitTopLevelBulletBlocks(lines) {
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    while (i < lines.length && String(lines[i]).trim() === "") i += 1;
+    if (i >= lines.length) break;
+    if (!isTopLevelBullet(lines[i])) {
+      i += 1;
+      continue;
+    }
+    const block = [];
+    while (i < lines.length) {
+      const line = lines[i];
+      if (line === undefined) break;
+      if (isTopLevelBullet(line) && block.length > 0) break;
+      if (block.length === 0 && !isTopLevelBullet(line)) break;
+      block.push(line);
+      i += 1;
+    }
+    if (block.length > 0) blocks.push(block);
+  }
+  return blocks;
+}
+
+function splitIndentedBulletBlocks(lines) {
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    while (i < lines.length && String(lines[i]).trim() === "") i += 1;
+    if (i >= lines.length) break;
+    if (!isIndentedBullet(lines[i])) {
+      i += 1;
+      continue;
+    }
+    const block = [];
+    while (i < lines.length) {
+      const line = lines[i];
+      if (line === undefined) break;
+      if (isIndentedBullet(line) && block.length > 0) break;
+      if (block.length === 0 && !isIndentedBullet(line)) break;
+      if (isTopLevelBullet(line)) break;
+      block.push(line);
+      i += 1;
+    }
+    if (block.length > 0) {
+      const normalized = block.map((ln, idx) => {
+        if (idx === 0) return `- ${stripListMarker(ln)}`;
+        if (ln.trim() === "") return "";
+        return `  ${ln.trimStart()}`;
+      });
+      blocks.push(normalized);
+    }
+  }
+  return blocks;
+}
+
+function bulletKey(block) {
+  if (!block || block.length === 0) return "";
+  return stripListMarker(block[0]).trim();
+}
+
+function appendUniqueBlocks(target, blocks) {
+  const seen = new Set(target.map(bulletKey));
+  for (const block of blocks) {
+    const key = bulletKey(block);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    target.push(block);
+  }
+}
+
+function classifySectionHeading(line, grouping) {
+  if (grouping === "bump-type") return classifyBumpHeading(line);
+  return classifyCategoryHeading(line);
+}
+
+/**
+ * Parse one RC notes file into package buckets + published versions.
+ * Accepts both package-then-category and category-then-package layouts.
+ */
+function parseRcNotes(content, order, grouping) {
+  const packages = new Map();
+  const published = [];
+  if (isEmptyNotesPlaceholder(content)) {
+    return { packages, published };
+  }
+
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  let i = 0;
+  let currentPackage = null;
+  let currentCategory = null;
+
+  const flushCategoryBlocks = (pkgName, cat, segmentLines) => {
+    if (!pkgName || !cat || !order.includes(cat)) return;
+    const pkg = ensurePackage(packages, pkgName, order);
+    const blocks = splitTopLevelBulletBlocks(segmentLines);
+    appendUniqueBlocks(pkg.buckets[cat], blocks);
+  };
+
+  const flushNestedPackageBlocks = (cat, segmentLines) => {
+    if (!cat || !order.includes(cat)) return;
+    let j = 0;
+    while (j < segmentLines.length) {
+      while (j < segmentLines.length && String(segmentLines[j]).trim() === "") j += 1;
+      if (j >= segmentLines.length) break;
+      const pkgName = packageBulletName(segmentLines[j]);
+      if (!pkgName) {
+        j += 1;
+        continue;
+      }
+      j += 1;
+      const nested = [];
+      while (j < segmentLines.length) {
+        const line = segmentLines[j];
+        if (packageBulletName(line)) break;
+        if (isTopLevelBullet(line) && !packageBulletName(line)) break;
+        nested.push(line);
+        j += 1;
+      }
+      const pkg = ensurePackage(packages, pkgName, order);
+      appendUniqueBlocks(pkg.buckets[cat], splitIndentedBulletBlocks(nested));
+    }
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const level = headingLevel(line);
+
+    if (isPublishedVersionsHeading(line)) {
+      i += 1;
+      while (i < lines.length && headingLevel(lines[i]) === 0) {
+        const m = String(lines[i]).match(/^[-*]\s+`([^`]+)`\s*$/);
+        if (m) published.push(m[1]);
+        i += 1;
+      }
+      continue;
+    }
+
+    if (level >= 2 && /^##\s+\S/.test(line) && !isPublishedVersionsHeading(line)) {
+      // Skip stray ## headings (e.g. legacy RC ids if re-rolled).
+      i += 1;
+      continue;
+    }
+
+    if (level === 3 || level === 4) {
+      const section = classifySectionHeading(line, grouping);
+      if (section) {
+        if (level === 3 && currentPackage === null) {
+          // category-then-package: ### Category
+          currentCategory = section;
+          i += 1;
+          const segment = [];
+          while (i < lines.length) {
+            const lvl = headingLevel(lines[i]);
+            if (lvl > 0 && lvl <= 3) break;
+            if (isPublishedVersionsHeading(lines[i])) break;
+            segment.push(lines[i]);
+            i += 1;
+          }
+          flushNestedPackageBlocks(currentCategory, segment);
+          currentCategory = null;
+          continue;
+        }
+        if (currentPackage !== null) {
+          // package-then-category: #### Category under ### package
+          currentCategory = section;
+          i += 1;
+          const segment = [];
+          while (i < lines.length) {
+            const lvl = headingLevel(lines[i]);
+            if (lvl > 0 && lvl <= 4) break;
+            if (isPublishedVersionsHeading(lines[i])) break;
+            segment.push(lines[i]);
+            i += 1;
+          }
+          flushCategoryBlocks(currentPackage, currentCategory, segment);
+          currentCategory = null;
+          continue;
+        }
+      }
+
+      if (level === 3 && !section) {
+        // package-then-category: ### @scope/name
+        currentPackage = String(line).replace(/^###\s+/, "").trim();
+        currentCategory = null;
+        i += 1;
+        continue;
+      }
+    }
+
+    i += 1;
+  }
+
+  return { packages, published };
+}
+
+function demoteHeading(title) {
+  return String(title).replace(/^###\s/, "#### ");
+}
+
+function emitTopLevelBullets(blocks) {
+  const out = [];
+  for (const block of blocks) {
+    if (!block || block.length === 0) continue;
+    out.push(...block);
+  }
+  return out;
+}
+
+function emitNestedUnderPackage(blocks) {
+  const out = [];
+  for (const block of blocks) {
+    if (!block || block.length === 0) continue;
+    out.push(`  - ${stripListMarker(block[0])}`);
+    for (let k = 1; k < block.length; k += 1) {
+      const ln = block[k];
+      if (ln === "") {
+        out.push("");
+        continue;
+      }
+      out.push(`    ${String(ln).trimStart()}`);
+    }
+  }
+  return out;
+}
+
+function emitCategoryThenPackage(packages, order, titles) {
+  const lines = [];
+  const sorted = [...packages.values()].sort((a, b) =>
+    a.name.localeCompare(b.name, "en"),
+  );
+  for (const cat of order) {
+    const withBlocks = sorted.filter((p) => p.buckets[cat]?.length > 0);
+    if (withBlocks.length === 0) continue;
+    lines.push(titles[cat], "");
+    for (const pkg of withBlocks) {
+      lines.push(`- **${pkg.name}**`);
+      lines.push(...emitNestedUnderPackage(pkg.buckets[cat]));
+      lines.push("");
+    }
+  }
+  return lines;
+}
+
+function emitPackageThenCategory(packages, order, titles) {
+  const lines = [];
+  const sorted = [...packages.values()].sort((a, b) =>
+    a.name.localeCompare(b.name, "en"),
+  );
+  for (const pkg of sorted) {
+    const cats = order.filter((cat) => pkg.buckets[cat]?.length > 0);
+    if (cats.length === 0) continue;
+    lines.push(`### ${pkg.name}`, "");
+    for (const cat of cats) {
+      lines.push(demoteHeading(titles[cat]), "");
+      lines.push(...emitTopLevelBullets(pkg.buckets[cat]));
+      lines.push("");
+    }
+  }
+  return lines;
+}
+
+function mergePublishedVersions(existing, next) {
+  // Later RCs win for the same package name (left of @).
+  const byName = new Map();
+  for (const entry of existing) {
+    const name = entry.includes("@")
+      ? entry.slice(0, entry.lastIndexOf("@"))
+      : entry;
+    byName.set(name, entry);
+  }
+  for (const entry of next) {
+    const name = entry.includes("@")
+      ? entry.slice(0, entry.lastIndexOf("@"))
+      : entry;
+    byName.set(name, entry);
+  }
+  return [...byName.values()].sort((a, b) => a.localeCompare(b, "en"));
+}
+
+async function main() {
   const cycleDir = process.argv[2];
   if (!cycleDir) {
     fail("usage: rollupReleaseNotes.mjs <.releases/cycle-id> [outfile]");
   }
+  if (
+    NESTING !== "package-then-category" &&
+    NESTING !== "category-then-package"
+  ) {
+    fail(
+      `invalid RELEASE_NOTES_NESTING "${NESTING}" ` +
+        `(expected package-then-category or category-then-package)`,
+    );
+  }
+  if (GROUPING !== "category" && GROUPING !== "bump-type") {
+    fail(
+      `invalid RELEASE_NOTES_GROUPING "${GROUPING}" (expected category or bump-type)`,
+    );
+  }
+
   const absCycleDir = path.resolve(cycleDir);
   const cycleId = path.basename(absCycleDir);
   const outPath =
@@ -27,15 +416,57 @@ function main() {
     fail(`no rc*/release-notes.md files found under ${absCycleDir}`);
   }
 
-  const sections = [];
-  for (const { index, notesPath } of rcNotes) {
-    const body = fs.readFileSync(notesPath, "utf8").trimEnd();
-    sections.push(`## ${cycleId}-rc${index}`, "", body, "");
+  let order;
+  let titles;
+  if (GROUPING === "bump-type") {
+    order = BUMP_TYPE_ORDER;
+    titles = BUMP_TYPE_TITLES;
+  } else {
+    const prefixes = await loadCategoryPrefixes();
+    order = prefixes.CATEGORY_ORDER;
+    titles = prefixes.CATEGORY_SECTION_TITLE;
   }
 
-  const content = `${sections.join("\n").trimEnd()}\n`;
+  const merged = new Map();
+  let published = [];
+
+  for (const { notesPath } of rcNotes) {
+    const body = fs.readFileSync(notesPath, "utf8");
+    const parsed = parseRcNotes(body, order, GROUPING);
+    for (const [name, pkg] of parsed.packages) {
+      const target = ensurePackage(merged, name, order);
+      for (const cat of order) {
+        appendUniqueBlocks(target.buckets[cat], pkg.buckets[cat]);
+      }
+    }
+    published = mergePublishedVersions(published, parsed.published);
+  }
+
+  const lines =
+    NESTING === "category-then-package"
+      ? emitCategoryThenPackage(merged, order, titles)
+      : emitPackageThenCategory(merged, order, titles);
+
+  if (published.length > 0) {
+    lines.push("## Published versions", "");
+    for (const entry of published) {
+      lines.push(`- \`${entry}\``);
+    }
+    lines.push("");
+  }
+
+  if (lines.length === 0) {
+    lines.push("_No CHANGELOG.md updates in this release cycle._", "");
+  }
+
+  const content = `${lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`;
   fs.writeFileSync(outPath, content, "utf8");
   process.stdout.write(`${outPath}\n`);
 }
 
-main();
+main().catch((err) => {
+  process.stderr.write(
+    `rollupReleaseNotes: ${err instanceof Error ? err.message : err}\n`,
+  );
+  process.exit(1);
+});

--- a/src/scripts/stageReleaseCycleWriter.sh
+++ b/src/scripts/stageReleaseCycleWriter.sh
@@ -818,23 +818,412 @@ CHIUBAKA_ORB_FINALIZE_RELEASE_CYCLE_V1_EOF
 cat >"${stage_dir}/rollupReleaseNotes.mjs" <<'CHIUBAKA_ORB_ROLLUP_RELEASE_NOTES_V1_EOF'
 #!/usr/bin/env node
 /**
- * Roll up per-RC release-notes.md into cycle release-notes.md (ADR 0041).
+ * Collate per-RC release-notes.md into cycle release-notes.md (ADR 0041).
+ *
+ * Merges all `rc<n>/release-notes.md` files into one document with the same
+ * nesting as formatChangesetsBatchReleaseNotes (default: package-then-category).
+ * Does not emit RC promotion headings — Artifact 3 is the full-cycle story
+ * without referencing soak candidates.
+ *
  * Usage: node rollupReleaseNotes.mjs <cycle-dir> [outfile]
+ *
+ * Env:
+ *   RELEASE_NOTES_GROUPING — category | bump-type (default category)
+ *   RELEASE_NOTES_NESTING — package-then-category | category-then-package
+ *   CHANGESET_CATEGORY_PREFIXES_SCRIPT — optional override for prefixes module
  */
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
 import { listRcNotesPaths } from "./lib/releaseCycle.mjs";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+const GROUPING = (process.env.RELEASE_NOTES_GROUPING || "category").toLowerCase();
+const NESTING = (
+  process.env.RELEASE_NOTES_NESTING || "package-then-category"
+).toLowerCase();
+
+const BUMP_TYPE_ORDER = ["major", "minor", "patch"];
+const BUMP_TYPE_TITLES = {
+  major: "### Major Changes",
+  minor: "### Minor Changes",
+  patch: "### Patch Changes",
+};
 
 function fail(msg) {
   process.stderr.write(`rollupReleaseNotes: ${msg}\n`);
   process.exit(1);
 }
 
-function main() {
+async function loadCategoryPrefixes() {
+  const override = process.env.CHANGESET_CATEGORY_PREFIXES_SCRIPT;
+  if (override) {
+    return import(pathToFileURL(path.resolve(override)).href);
+  }
+  return import(pathToFileURL(path.join(SCRIPT_DIR, "changesetCategoryPrefixes.mjs")).href);
+}
+
+function classifyCategoryHeading(line) {
+  const t = String(line).trim().replace(/^#{1,6}\s+/, "");
+  if (/^Breaking(?:\s+Changes)?$/i.test(t)) return "breaking";
+  if (/^Security$/i.test(t)) return "security";
+  if (/^Features?$/i.test(t)) return "features";
+  if (/^Improvements?$/i.test(t)) return "improvements";
+  if (/^(?:Bug\s+)?Fix(?:es)?$/i.test(t)) return "bugfixes";
+  if (/^Deprecations?$/i.test(t)) return "deprecations";
+  if (/^Other(?:\s+Changes)?$/i.test(t)) return "other";
+  return null;
+}
+
+function classifyBumpHeading(line) {
+  const t = String(line).trim().replace(/^#{1,6}\s+/, "");
+  const m = t.match(/^(Major|Minor|Patch)(?:\s+Changes)?$/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+function headingLevel(line) {
+  const m = String(line).match(/^(#{1,6})\s+\S/);
+  return m ? m[1].length : 0;
+}
+
+function isPublishedVersionsHeading(line) {
+  return /^##\s+Published versions\s*$/i.test(String(line).trim());
+}
+
+function isEmptyNotesPlaceholder(text) {
+  return /_No CHANGELOG\.md updates in this version cut\._/i.test(text);
+}
+
+function emptyBuckets(order) {
+  return Object.fromEntries(order.map((key) => [key, []]));
+}
+
+function ensurePackage(map, name, order) {
+  if (!map.has(name)) {
+    map.set(name, { name, buckets: emptyBuckets(order) });
+  }
+  return map.get(name);
+}
+
+function isTopLevelBullet(line) {
+  const t = String(line).replace(/\r$/, "");
+  return /^[-*]\s/.test(t) && !/^\s/.test(t);
+}
+
+function isIndentedBullet(line) {
+  return /^\s{2,}[-*]\s/.test(String(line));
+}
+
+function packageBulletName(line) {
+  const m = String(line).match(/^[-*]\s+\*\*(.+?)\*\*\s*$/);
+  return m ? m[1].trim() : null;
+}
+
+function stripListMarker(line) {
+  return String(line).replace(/^\s*[-*]\s+/, "");
+}
+
+function splitTopLevelBulletBlocks(lines) {
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    while (i < lines.length && String(lines[i]).trim() === "") i += 1;
+    if (i >= lines.length) break;
+    if (!isTopLevelBullet(lines[i])) {
+      i += 1;
+      continue;
+    }
+    const block = [];
+    while (i < lines.length) {
+      const line = lines[i];
+      if (line === undefined) break;
+      if (isTopLevelBullet(line) && block.length > 0) break;
+      if (block.length === 0 && !isTopLevelBullet(line)) break;
+      block.push(line);
+      i += 1;
+    }
+    if (block.length > 0) blocks.push(block);
+  }
+  return blocks;
+}
+
+function splitIndentedBulletBlocks(lines) {
+  const blocks = [];
+  let i = 0;
+  while (i < lines.length) {
+    while (i < lines.length && String(lines[i]).trim() === "") i += 1;
+    if (i >= lines.length) break;
+    if (!isIndentedBullet(lines[i])) {
+      i += 1;
+      continue;
+    }
+    const block = [];
+    while (i < lines.length) {
+      const line = lines[i];
+      if (line === undefined) break;
+      if (isIndentedBullet(line) && block.length > 0) break;
+      if (block.length === 0 && !isIndentedBullet(line)) break;
+      if (isTopLevelBullet(line)) break;
+      block.push(line);
+      i += 1;
+    }
+    if (block.length > 0) {
+      const normalized = block.map((ln, idx) => {
+        if (idx === 0) return `- ${stripListMarker(ln)}`;
+        if (ln.trim() === "") return "";
+        return `  ${ln.trimStart()}`;
+      });
+      blocks.push(normalized);
+    }
+  }
+  return blocks;
+}
+
+function bulletKey(block) {
+  if (!block || block.length === 0) return "";
+  return stripListMarker(block[0]).trim();
+}
+
+function appendUniqueBlocks(target, blocks) {
+  const seen = new Set(target.map(bulletKey));
+  for (const block of blocks) {
+    const key = bulletKey(block);
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    target.push(block);
+  }
+}
+
+function classifySectionHeading(line, grouping) {
+  if (grouping === "bump-type") return classifyBumpHeading(line);
+  return classifyCategoryHeading(line);
+}
+
+/**
+ * Parse one RC notes file into package buckets + published versions.
+ * Accepts both package-then-category and category-then-package layouts.
+ */
+function parseRcNotes(content, order, grouping) {
+  const packages = new Map();
+  const published = [];
+  if (isEmptyNotesPlaceholder(content)) {
+    return { packages, published };
+  }
+
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  let i = 0;
+  let currentPackage = null;
+  let currentCategory = null;
+
+  const flushCategoryBlocks = (pkgName, cat, segmentLines) => {
+    if (!pkgName || !cat || !order.includes(cat)) return;
+    const pkg = ensurePackage(packages, pkgName, order);
+    const blocks = splitTopLevelBulletBlocks(segmentLines);
+    appendUniqueBlocks(pkg.buckets[cat], blocks);
+  };
+
+  const flushNestedPackageBlocks = (cat, segmentLines) => {
+    if (!cat || !order.includes(cat)) return;
+    let j = 0;
+    while (j < segmentLines.length) {
+      while (j < segmentLines.length && String(segmentLines[j]).trim() === "") j += 1;
+      if (j >= segmentLines.length) break;
+      const pkgName = packageBulletName(segmentLines[j]);
+      if (!pkgName) {
+        j += 1;
+        continue;
+      }
+      j += 1;
+      const nested = [];
+      while (j < segmentLines.length) {
+        const line = segmentLines[j];
+        if (packageBulletName(line)) break;
+        if (isTopLevelBullet(line) && !packageBulletName(line)) break;
+        nested.push(line);
+        j += 1;
+      }
+      const pkg = ensurePackage(packages, pkgName, order);
+      appendUniqueBlocks(pkg.buckets[cat], splitIndentedBulletBlocks(nested));
+    }
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const level = headingLevel(line);
+
+    if (isPublishedVersionsHeading(line)) {
+      i += 1;
+      while (i < lines.length && headingLevel(lines[i]) === 0) {
+        const m = String(lines[i]).match(/^[-*]\s+`([^`]+)`\s*$/);
+        if (m) published.push(m[1]);
+        i += 1;
+      }
+      continue;
+    }
+
+    if (level >= 2 && /^##\s+\S/.test(line) && !isPublishedVersionsHeading(line)) {
+      // Skip stray ## headings (e.g. legacy RC ids if re-rolled).
+      i += 1;
+      continue;
+    }
+
+    if (level === 3 || level === 4) {
+      const section = classifySectionHeading(line, grouping);
+      if (section) {
+        if (level === 3 && currentPackage === null) {
+          // category-then-package: ### Category
+          currentCategory = section;
+          i += 1;
+          const segment = [];
+          while (i < lines.length) {
+            const lvl = headingLevel(lines[i]);
+            if (lvl > 0 && lvl <= 3) break;
+            if (isPublishedVersionsHeading(lines[i])) break;
+            segment.push(lines[i]);
+            i += 1;
+          }
+          flushNestedPackageBlocks(currentCategory, segment);
+          currentCategory = null;
+          continue;
+        }
+        if (currentPackage !== null) {
+          // package-then-category: #### Category under ### package
+          currentCategory = section;
+          i += 1;
+          const segment = [];
+          while (i < lines.length) {
+            const lvl = headingLevel(lines[i]);
+            if (lvl > 0 && lvl <= 4) break;
+            if (isPublishedVersionsHeading(lines[i])) break;
+            segment.push(lines[i]);
+            i += 1;
+          }
+          flushCategoryBlocks(currentPackage, currentCategory, segment);
+          currentCategory = null;
+          continue;
+        }
+      }
+
+      if (level === 3 && !section) {
+        // package-then-category: ### @scope/name
+        currentPackage = String(line).replace(/^###\s+/, "").trim();
+        currentCategory = null;
+        i += 1;
+        continue;
+      }
+    }
+
+    i += 1;
+  }
+
+  return { packages, published };
+}
+
+function demoteHeading(title) {
+  return String(title).replace(/^###\s/, "#### ");
+}
+
+function emitTopLevelBullets(blocks) {
+  const out = [];
+  for (const block of blocks) {
+    if (!block || block.length === 0) continue;
+    out.push(...block);
+  }
+  return out;
+}
+
+function emitNestedUnderPackage(blocks) {
+  const out = [];
+  for (const block of blocks) {
+    if (!block || block.length === 0) continue;
+    out.push(`  - ${stripListMarker(block[0])}`);
+    for (let k = 1; k < block.length; k += 1) {
+      const ln = block[k];
+      if (ln === "") {
+        out.push("");
+        continue;
+      }
+      out.push(`    ${String(ln).trimStart()}`);
+    }
+  }
+  return out;
+}
+
+function emitCategoryThenPackage(packages, order, titles) {
+  const lines = [];
+  const sorted = [...packages.values()].sort((a, b) =>
+    a.name.localeCompare(b.name, "en"),
+  );
+  for (const cat of order) {
+    const withBlocks = sorted.filter((p) => p.buckets[cat]?.length > 0);
+    if (withBlocks.length === 0) continue;
+    lines.push(titles[cat], "");
+    for (const pkg of withBlocks) {
+      lines.push(`- **${pkg.name}**`);
+      lines.push(...emitNestedUnderPackage(pkg.buckets[cat]));
+      lines.push("");
+    }
+  }
+  return lines;
+}
+
+function emitPackageThenCategory(packages, order, titles) {
+  const lines = [];
+  const sorted = [...packages.values()].sort((a, b) =>
+    a.name.localeCompare(b.name, "en"),
+  );
+  for (const pkg of sorted) {
+    const cats = order.filter((cat) => pkg.buckets[cat]?.length > 0);
+    if (cats.length === 0) continue;
+    lines.push(`### ${pkg.name}`, "");
+    for (const cat of cats) {
+      lines.push(demoteHeading(titles[cat]), "");
+      lines.push(...emitTopLevelBullets(pkg.buckets[cat]));
+      lines.push("");
+    }
+  }
+  return lines;
+}
+
+function mergePublishedVersions(existing, next) {
+  // Later RCs win for the same package name (left of @).
+  const byName = new Map();
+  for (const entry of existing) {
+    const name = entry.includes("@")
+      ? entry.slice(0, entry.lastIndexOf("@"))
+      : entry;
+    byName.set(name, entry);
+  }
+  for (const entry of next) {
+    const name = entry.includes("@")
+      ? entry.slice(0, entry.lastIndexOf("@"))
+      : entry;
+    byName.set(name, entry);
+  }
+  return [...byName.values()].sort((a, b) => a.localeCompare(b, "en"));
+}
+
+async function main() {
   const cycleDir = process.argv[2];
   if (!cycleDir) {
     fail("usage: rollupReleaseNotes.mjs <.releases/cycle-id> [outfile]");
   }
+  if (
+    NESTING !== "package-then-category" &&
+    NESTING !== "category-then-package"
+  ) {
+    fail(
+      `invalid RELEASE_NOTES_NESTING "${NESTING}" ` +
+        `(expected package-then-category or category-then-package)`,
+    );
+  }
+  if (GROUPING !== "category" && GROUPING !== "bump-type") {
+    fail(
+      `invalid RELEASE_NOTES_GROUPING "${GROUPING}" (expected category or bump-type)`,
+    );
+  }
+
   const absCycleDir = path.resolve(cycleDir);
   const cycleId = path.basename(absCycleDir);
   const outPath =
@@ -845,19 +1234,60 @@ function main() {
     fail(`no rc*/release-notes.md files found under ${absCycleDir}`);
   }
 
-  const sections = [];
-  for (const { index, notesPath } of rcNotes) {
-    const body = fs.readFileSync(notesPath, "utf8").trimEnd();
-    sections.push(`## ${cycleId}-rc${index}`, "", body, "");
+  let order;
+  let titles;
+  if (GROUPING === "bump-type") {
+    order = BUMP_TYPE_ORDER;
+    titles = BUMP_TYPE_TITLES;
+  } else {
+    const prefixes = await loadCategoryPrefixes();
+    order = prefixes.CATEGORY_ORDER;
+    titles = prefixes.CATEGORY_SECTION_TITLE;
   }
 
-  const content = `${sections.join("\n").trimEnd()}\n`;
+  const merged = new Map();
+  let published = [];
+
+  for (const { notesPath } of rcNotes) {
+    const body = fs.readFileSync(notesPath, "utf8");
+    const parsed = parseRcNotes(body, order, GROUPING);
+    for (const [name, pkg] of parsed.packages) {
+      const target = ensurePackage(merged, name, order);
+      for (const cat of order) {
+        appendUniqueBlocks(target.buckets[cat], pkg.buckets[cat]);
+      }
+    }
+    published = mergePublishedVersions(published, parsed.published);
+  }
+
+  const lines =
+    NESTING === "category-then-package"
+      ? emitCategoryThenPackage(merged, order, titles)
+      : emitPackageThenCategory(merged, order, titles);
+
+  if (published.length > 0) {
+    lines.push("## Published versions", "");
+    for (const entry of published) {
+      lines.push(`- \`${entry}\``);
+    }
+    lines.push("");
+  }
+
+  if (lines.length === 0) {
+    lines.push("_No CHANGELOG.md updates in this release cycle._", "");
+  }
+
+  const content = `${lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd()}\n`;
   fs.writeFileSync(outPath, content, "utf8");
   process.stdout.write(`${outPath}\n`);
 }
 
-main();
-
+main().catch((err) => {
+  process.stderr.write(
+    `rollupReleaseNotes: ${err instanceof Error ? err.message : err}\n`,
+  );
+  process.exit(1);
+});
 CHIUBAKA_ORB_ROLLUP_RELEASE_NOTES_V1_EOF
 cat >"${stage_dir}/validateReleaseCycle.mjs" <<'CHIUBAKA_ORB_VALIDATE_RELEASE_CYCLE_V1_EOF'
 #!/usr/bin/env node

--- a/src/scripts/stageReleaseCycleWriter.sh
+++ b/src/scripts/stageReleaseCycleWriter.sh
@@ -831,6 +831,8 @@ cat >"${stage_dir}/rollupReleaseNotes.mjs" <<'CHIUBAKA_ORB_ROLLUP_RELEASE_NOTES_
  *   RELEASE_NOTES_GROUPING — category | bump-type (default category)
  *   RELEASE_NOTES_NESTING — package-then-category | category-then-package
  *   CHANGESET_CATEGORY_PREFIXES_SCRIPT — optional override for prefixes module
+ *   ROLLUP_ALLOW_UNPARSED_RELEASE_NOTES — when "true", warn on unparsed lines
+ *     instead of failing (default: fail)
  */
 import fs from "node:fs";
 import path from "node:path";
@@ -864,15 +866,13 @@ async function loadCategoryPrefixes() {
   return import(pathToFileURL(path.join(SCRIPT_DIR, "changesetCategoryPrefixes.mjs")).href);
 }
 
-function classifyCategoryHeading(line) {
+function classifyCategoryHeading(line, titles) {
   const t = String(line).trim().replace(/^#{1,6}\s+/, "");
-  if (/^Breaking(?:\s+Changes)?$/i.test(t)) return "breaking";
-  if (/^Security$/i.test(t)) return "security";
-  if (/^Features?$/i.test(t)) return "features";
-  if (/^Improvements?$/i.test(t)) return "improvements";
-  if (/^(?:Bug\s+)?Fix(?:es)?$/i.test(t)) return "bugfixes";
-  if (/^Deprecations?$/i.test(t)) return "deprecations";
-  if (/^Other(?:\s+Changes)?$/i.test(t)) return "other";
+  const normalized = t.toLowerCase();
+  for (const [key, title] of Object.entries(titles ?? {})) {
+    const bare = String(title).replace(/^#+\s*/, "").trim().toLowerCase();
+    if (normalized === bare) return key;
+  }
   return null;
 }
 
@@ -880,6 +880,11 @@ function classifyBumpHeading(line) {
   const t = String(line).trim().replace(/^#{1,6}\s+/, "");
   const m = t.match(/^(Major|Minor|Patch)(?:\s+Changes)?$/i);
   return m ? m[1].toLowerCase() : null;
+}
+
+function classifySectionHeading(line, grouping, titles) {
+  if (grouping === "bump-type") return classifyBumpHeading(line);
+  return classifyCategoryHeading(line, titles);
 }
 
 function headingLevel(line) {
@@ -926,9 +931,14 @@ function stripListMarker(line) {
 
 function splitTopLevelBulletBlocks(lines) {
   const blocks = [];
+  /** @type {number[]} */
+  const consumedOffsets = [];
   let i = 0;
   while (i < lines.length) {
-    while (i < lines.length && String(lines[i]).trim() === "") i += 1;
+    while (i < lines.length && String(lines[i]).trim() === "") {
+      consumedOffsets.push(i);
+      i += 1;
+    }
     if (i >= lines.length) break;
     if (!isTopLevelBullet(lines[i])) {
       i += 1;
@@ -941,18 +951,24 @@ function splitTopLevelBulletBlocks(lines) {
       if (isTopLevelBullet(line) && block.length > 0) break;
       if (block.length === 0 && !isTopLevelBullet(line)) break;
       block.push(line);
+      consumedOffsets.push(i);
       i += 1;
     }
     if (block.length > 0) blocks.push(block);
   }
-  return blocks;
+  return { blocks, consumedOffsets };
 }
 
 function splitIndentedBulletBlocks(lines) {
   const blocks = [];
+  /** @type {number[]} */
+  const consumedOffsets = [];
   let i = 0;
   while (i < lines.length) {
-    while (i < lines.length && String(lines[i]).trim() === "") i += 1;
+    while (i < lines.length && String(lines[i]).trim() === "") {
+      consumedOffsets.push(i);
+      i += 1;
+    }
     if (i >= lines.length) break;
     if (!isIndentedBullet(lines[i])) {
       i += 1;
@@ -966,6 +982,7 @@ function splitIndentedBulletBlocks(lines) {
       if (block.length === 0 && !isIndentedBullet(line)) break;
       if (isTopLevelBullet(line)) break;
       block.push(line);
+      consumedOffsets.push(i);
       i += 1;
     }
     if (block.length > 0) {
@@ -977,7 +994,7 @@ function splitIndentedBulletBlocks(lines) {
       blocks.push(normalized);
     }
   }
-  return blocks;
+  return { blocks, consumedOffsets };
 }
 
 function bulletKey(block) {
@@ -995,46 +1012,58 @@ function appendUniqueBlocks(target, blocks) {
   }
 }
 
-function classifySectionHeading(line, grouping) {
-  if (grouping === "bump-type") return classifyBumpHeading(line);
-  return classifyCategoryHeading(line);
-}
-
 /**
  * Parse one RC notes file into package buckets + published versions.
  * Accepts both package-then-category and category-then-package layouts.
+ * @returns {{ packages: Map<string, {name: string, buckets: Record<string, string[][]>}>, published: string[], unparsed: {line: number, text: string}[] }}
  */
-function parseRcNotes(content, order, grouping) {
+function parseRcNotes(content, order, grouping, titles) {
   const packages = new Map();
   const published = [];
+  /** @type {Set<number>} */
+  const consumed = new Set();
+  const mark = (...idxs) => {
+    for (const idx of idxs) {
+      if (typeof idx === "number" && idx >= 0) consumed.add(idx);
+    }
+  };
+  const markOffsets = (base, offsets) => {
+    for (const offset of offsets) mark(base + offset);
+  };
+
   if (isEmptyNotesPlaceholder(content)) {
-    return { packages, published };
+    return { packages, published, unparsed: [] };
   }
 
   const lines = content.replace(/\r\n/g, "\n").split("\n");
   let i = 0;
   let currentPackage = null;
-  let currentCategory = null;
 
-  const flushCategoryBlocks = (pkgName, cat, segmentLines) => {
+  const flushCategoryBlocks = (pkgName, cat, segmentStart, segmentLines) => {
     if (!pkgName || !cat || !order.includes(cat)) return;
     const pkg = ensurePackage(packages, pkgName, order);
-    const blocks = splitTopLevelBulletBlocks(segmentLines);
+    const { blocks, consumedOffsets } = splitTopLevelBulletBlocks(segmentLines);
     appendUniqueBlocks(pkg.buckets[cat], blocks);
+    markOffsets(segmentStart, consumedOffsets);
   };
 
-  const flushNestedPackageBlocks = (cat, segmentLines) => {
+  const flushNestedPackageBlocks = (cat, segmentStart, segmentLines) => {
     if (!cat || !order.includes(cat)) return;
     let j = 0;
     while (j < segmentLines.length) {
-      while (j < segmentLines.length && String(segmentLines[j]).trim() === "") j += 1;
+      while (j < segmentLines.length && String(segmentLines[j]).trim() === "") {
+        mark(segmentStart + j);
+        j += 1;
+      }
       if (j >= segmentLines.length) break;
       const pkgName = packageBulletName(segmentLines[j]);
       if (!pkgName) {
         j += 1;
         continue;
       }
+      mark(segmentStart + j);
       j += 1;
+      const nestedStart = j;
       const nested = [];
       while (j < segmentLines.length) {
         const line = segmentLines[j];
@@ -1044,7 +1073,9 @@ function parseRcNotes(content, order, grouping) {
         j += 1;
       }
       const pkg = ensurePackage(packages, pkgName, order);
-      appendUniqueBlocks(pkg.buckets[cat], splitIndentedBulletBlocks(nested));
+      const { blocks, consumedOffsets } = splitIndentedBulletBlocks(nested);
+      appendUniqueBlocks(pkg.buckets[cat], blocks);
+      markOffsets(segmentStart + nestedStart, consumedOffsets);
     }
   };
 
@@ -1053,28 +1084,34 @@ function parseRcNotes(content, order, grouping) {
     const level = headingLevel(line);
 
     if (isPublishedVersionsHeading(line)) {
+      mark(i);
       i += 1;
       while (i < lines.length && headingLevel(lines[i]) === 0) {
         const m = String(lines[i]).match(/^[-*]\s+`([^`]+)`\s*$/);
-        if (m) published.push(m[1]);
+        if (m) {
+          published.push(m[1]);
+          mark(i);
+        } else if (String(lines[i]).trim() === "") {
+          mark(i);
+        }
         i += 1;
       }
       continue;
     }
 
     if (level >= 2 && /^##\s+\S/.test(line) && !isPublishedVersionsHeading(line)) {
-      // Skip stray ## headings (e.g. legacy RC ids if re-rolled).
+      // Leave unrecognized ## sections unparsed (including following body).
       i += 1;
       continue;
     }
 
     if (level === 3 || level === 4) {
-      const section = classifySectionHeading(line, grouping);
+      const section = classifySectionHeading(line, grouping, titles);
       if (section) {
         if (level === 3 && currentPackage === null) {
-          // category-then-package: ### Category
-          currentCategory = section;
+          mark(i);
           i += 1;
+          const segmentStart = i;
           const segment = [];
           while (i < lines.length) {
             const lvl = headingLevel(lines[i]);
@@ -1083,14 +1120,13 @@ function parseRcNotes(content, order, grouping) {
             segment.push(lines[i]);
             i += 1;
           }
-          flushNestedPackageBlocks(currentCategory, segment);
-          currentCategory = null;
+          flushNestedPackageBlocks(section, segmentStart, segment);
           continue;
         }
         if (currentPackage !== null) {
-          // package-then-category: #### Category under ### package
-          currentCategory = section;
+          mark(i);
           i += 1;
+          const segmentStart = i;
           const segment = [];
           while (i < lines.length) {
             const lvl = headingLevel(lines[i]);
@@ -1099,25 +1135,33 @@ function parseRcNotes(content, order, grouping) {
             segment.push(lines[i]);
             i += 1;
           }
-          flushCategoryBlocks(currentPackage, currentCategory, segment);
-          currentCategory = null;
+          flushCategoryBlocks(currentPackage, section, segmentStart, segment);
           continue;
         }
       }
 
       if (level === 3 && !section) {
-        // package-then-category: ### @scope/name
         currentPackage = String(line).replace(/^###\s+/, "").trim();
-        currentCategory = null;
+        mark(i);
         i += 1;
         continue;
       }
     }
 
+    if (String(line).trim() === "") {
+      mark(i);
+    }
     i += 1;
   }
 
-  return { packages, published };
+  const unparsed = [];
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    if (consumed.has(idx)) continue;
+    if (String(lines[idx]).trim() === "") continue;
+    unparsed.push({ line: idx + 1, text: lines[idx] });
+  }
+
+  return { packages, published, unparsed };
 }
 
 function demoteHeading(title) {
@@ -1247,10 +1291,16 @@ async function main() {
 
   const merged = new Map();
   let published = [];
+  const allowUnparsed =
+    String(process.env.ROLLUP_ALLOW_UNPARSED_RELEASE_NOTES || "")
+      .trim()
+      .toLowerCase() === "true";
+  /** @type {{ path: string, line: number, text: string }[]} */
+  const unparsedAll = [];
 
   for (const { notesPath } of rcNotes) {
     const body = fs.readFileSync(notesPath, "utf8");
-    const parsed = parseRcNotes(body, order, GROUPING);
+    const parsed = parseRcNotes(body, order, GROUPING, titles);
     for (const [name, pkg] of parsed.packages) {
       const target = ensurePackage(merged, name, order);
       for (const cat of order) {
@@ -1258,6 +1308,26 @@ async function main() {
       }
     }
     published = mergePublishedVersions(published, parsed.published);
+    for (const entry of parsed.unparsed) {
+      unparsedAll.push({ path: notesPath, ...entry });
+    }
+  }
+
+  if (unparsedAll.length > 0) {
+    const samples = unparsedAll
+      .slice(0, 5)
+      .map((entry) => `${entry.path}:${entry.line}: ${entry.text.trim()}`)
+      .join("\n");
+    const detail =
+      `unparsed ${unparsedAll.length} line(s) in rc release-notes ` +
+      `(would be omitted from cycle Artifact 3). Examples:\n${samples}`;
+    if (allowUnparsed) {
+      process.stderr.write(`rollupReleaseNotes: warning: ${detail}\n`);
+    } else {
+      fail(
+        `${detail}\nSet ROLLUP_ALLOW_UNPARSED_RELEASE_NOTES=true to warn instead of fail.`,
+      );
+    }
   }
 
   const lines =

--- a/test/fixtures/release-cycles/2026.05.08.1/rc1/release-notes.md
+++ b/test/fixtures/release-cycles/2026.05.08.1/rc1/release-notes.md
@@ -3,3 +3,7 @@
 #### Bug Fixes
 
 - Fix export queue handling
+
+## Published versions
+
+- `@chiubaka/server@1.2.3`

--- a/test/fixtures/release-cycles/2026.05.08.1/rc1/release-notes.md
+++ b/test/fixtures/release-cycles/2026.05.08.1/rc1/release-notes.md
@@ -1,4 +1,5 @@
-### Bug Fixes
+### @chiubaka/server
 
-- **@chiubaka/server**
-  - Fix export queue handling
+#### Bug Fixes
+
+- Fix export queue handling

--- a/test/fixtures/release-cycles/2026.05.08.1/release-notes.md
+++ b/test/fixtures/release-cycles/2026.05.08.1/release-notes.md
@@ -3,3 +3,7 @@
 #### Bug Fixes
 
 - Fix export queue handling
+
+## Published versions
+
+- `@chiubaka/server@1.2.3`

--- a/test/fixtures/release-cycles/2026.05.08.1/release-notes.md
+++ b/test/fixtures/release-cycles/2026.05.08.1/release-notes.md
@@ -1,6 +1,5 @@
-## 2026.05.08.1-rc1
+### @chiubaka/server
 
-### Bug Fixes
+#### Bug Fixes
 
-- **@chiubaka/server**
-  - Fix export queue handling
+- Fix export queue handling

--- a/test/releaseCycleWorkflow.bats
+++ b/test/releaseCycleWorkflow.bats
@@ -41,7 +41,7 @@ setup() {
   assert_output --partial "missing release-notes.md"
 }
 
-@test "rollup writes release-notes.md with rc headings" {
+@test "rollup collates RC notes without RC headings" {
   work="${BATS_TEST_TMPDIR}/rollup-cycle"
   mkdir -p "$work"
   cp -a "$PROJECT_ROOT/test/fixtures/release-cycles/2026.05.08.1" "$work/"
@@ -49,13 +49,35 @@ setup() {
   run node "$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" "$work/2026.05.08.1"
   assert_success
   assert [ -f "$work/2026.05.08.1/release-notes.md" ]
-  run grep -F "## 2026.05.08.1-rc1" "$work/2026.05.08.1/release-notes.md"
+  run grep -F "### @chiubaka/server" "$work/2026.05.08.1/release-notes.md"
   assert_success
+  run grep -F "#### Bug Fixes" "$work/2026.05.08.1/release-notes.md"
+  assert_success
+  run grep -F "## 2026.05.08.1-rc1" "$work/2026.05.08.1/release-notes.md"
+  assert_failure
 
   mkdir -p "$work/2026.05.08.1/rc2"
-  cp "$work/2026.05.08.1/rc1/release-notes.md" "$work/2026.05.08.1/rc2/release-notes.md"
+  cat >"$work/2026.05.08.1/rc2/release-notes.md" <<'EOF'
+### @chiubaka/server
+
+#### Features
+
+- Add soak patch feature
+
+## Published versions
+
+- `@chiubaka/server@1.2.4`
+EOF
   run node "$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" "$work/2026.05.08.1"
   assert_success
+  run grep -F "#### Features" "$work/2026.05.08.1/release-notes.md"
+  assert_success
+  run grep -F "Add soak patch feature" "$work/2026.05.08.1/release-notes.md"
+  assert_success
+  run grep -F "Fix export queue handling" "$work/2026.05.08.1/release-notes.md"
+  assert_success
   run grep -F "## 2026.05.08.1-rc2" "$work/2026.05.08.1/release-notes.md"
+  assert_failure
+  run grep -F '@chiubaka/server@1.2.4' "$work/2026.05.08.1/release-notes.md"
   assert_success
 }

--- a/test/releaseCycleWorkflow.bats
+++ b/test/releaseCycleWorkflow.bats
@@ -64,6 +64,10 @@ setup() {
 
 - Add soak patch feature
 
+#### Bug Fixes
+
+- Fix export queue handling
+
 ## Published versions
 
 - `@chiubaka/server@1.2.4`
@@ -76,8 +80,34 @@ EOF
   assert_success
   run grep -F "Fix export queue handling" "$work/2026.05.08.1/release-notes.md"
   assert_success
+  # Repeated rc1 bullet must appear exactly once after collation.
+  run bash -c "grep -cF 'Fix export queue handling' '$work/2026.05.08.1/release-notes.md'"
+  assert_output "1"
   run grep -F "## 2026.05.08.1-rc2" "$work/2026.05.08.1/release-notes.md"
   assert_failure
   run grep -F '@chiubaka/server@1.2.4' "$work/2026.05.08.1/release-notes.md"
   assert_success
+  # Later RC published pin supersedes the earlier one.
+  run grep -F '@chiubaka/server@1.2.3' "$work/2026.05.08.1/release-notes.md"
+  assert_failure
+}
+
+@test "rollup fails when rc notes contain unparsed content" {
+  work="${BATS_TEST_TMPDIR}/rollup-unparsed"
+  mkdir -p "$work/2026.05.08.1/rc1"
+  printf 'release: 2026.05.08.1\nopenedAt: 2026-05-08T00:00:00Z\n' \
+    >"$work/2026.05.08.1/cycle.yml"
+  cat >"$work/2026.05.08.1/rc1/release-notes.md" <<'EOF'
+### @chiubaka/server
+
+#### Bug Fixes
+
+This prose is not a bullet and must not be silently dropped.
+
+- Fix export queue handling
+EOF
+  run node "$PROJECT_ROOT/src/scripts/rollupReleaseNotes.mjs" "$work/2026.05.08.1"
+  assert_failure
+  assert_output --partial "unparsed"
+  assert_output --partial "This prose is not a bullet"
 }

--- a/test/writeReleaseCycle.bats
+++ b/test/writeReleaseCycle.bats
@@ -43,6 +43,9 @@ _init_git_with_origin() {
   assert [ -f ".releases/2099.12.31.1/rc1/release-notes.md" ]
   assert [ -f ".releases/2099.12.31.1/release-notes.md" ]
   run grep -F "## 2099.12.31.1-rc1" ".releases/2099.12.31.1/release-notes.md"
+  assert_failure
+  run grep -F "_No CHANGELOG.md updates in this release cycle._" \
+    ".releases/2099.12.31.1/release-notes.md"
   assert_success
   run grep -F "release: 2099.12.31.1" ".releases/2099.12.31.1/cycle.yml"
   assert_success


### PR DESCRIPTION
## Summary
- Cycle-level `release-notes.md` (Artifact 3 / GitHub Release body) now **collates** all `rc*/release-notes.md` into one changelog using the same nesting as batch notes (default package-then-category), instead of concatenating per-RC sections headed by `<cycle-id>-rcN`.
- Duplicate bullets across soak cuts are deduped; published versions keep the latest pin per package.
- ADRs 0041–0043 and the review-artifacts example updated to match the collated Artifact 3 shape (fixes the `prod-2026.07.08.1` style RC-sectioned release body).

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (230 bats)
- [ ] Promote a multi-RC soak cycle with the new orb and confirm the GitHub Release body has no `## …-rcN` sections and groups by package then category


Made with [Cursor](https://cursor.com)