### PR TITLE
chore(release): version packages (@chiubaka/circleci-orb@0.25.0)

### DIFF
--- a/.changeset/collate-cycle-release-notes.md
+++ b/.changeset/collate-cycle-release-notes.md
@@ -1,5 +1,0 @@
----
-"@chiubaka/circleci-orb": minor
----
-
-Feature: Collate multi-RC cycle release notes into one package-then-category changelog without RC section headings

--- a/.changeset/split-promote-gate-params.md
+++ b/.changeset/split-promote-gate-params.md
@@ -1,7 +1,0 @@
----
-"@chiubaka/circleci-orb": minor
----
-
-Fix: Stop finalize commits from re-opening gated publish and promote-prod via split continuation parameters.
-
-`compute-changesets-publish-parameters` now emits `run-changesets-publish` only for version-packages release merges (path signal + subject) and adds `offer-promote-prod` when that merge’s tip-commit release cycle (same highest `.releases/<cycle-id>/rc<n>` resolution as `promote-prod-release`) still has no non-empty `promotedAt`. Gate `promote-prod` on `offer-promote-prod`, not the publish flag alone.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @chiubaka/circleci-orb
 
+## 0.25.0
+
+### Features
+
+- Collate multi-RC cycle release notes into one package-then-category changelog without RC section headings
+
+### Bug Fixes
+
+- Stop finalize commits from re-opening gated publish and promote-prod via split continuation parameters.
+
+  `compute-changesets-publish-parameters` now emits `run-changesets-publish` only for version-packages release merges (path signal + subject) and adds `offer-promote-prod` when that merge’s tip-commit release cycle (same highest `.releases/<cycle-id>/rc<n>` resolution as `promote-prod-release`) still has no non-empty `promotedAt`. Gate `promote-prod` on `offer-promote-prod`, not the publish flag alone.
+
 ## 0.24.3
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiubaka/circleci-orb",
-  "version": "0.24.3",
+  "version": "0.25.0",
   "private": true,
   "description": "CircleCI Orb for common Chiubaka Technologies CI/CD tasks",
   "main": "index.js",


### PR DESCRIPTION
### @chiubaka/circleci-orb

#### Features

- Collate multi-RC cycle release notes into one package-then-category changelog without RC section headings

#### Bug Fixes

- Stop finalize commits from re-opening gated publish and promote-prod via split continuation parameters.

    `compute-changesets-publish-parameters` now emits `run-changesets-publish` only for version-packages release merges (path signal + subject) and adds `offer-promote-prod` when that merge’s tip-commit release cycle (same highest `.releases/<cycle-id>/rc<n>` resolution as `promote-prod-release`) still has no non-empty `promotedAt`. Gate `promote-prod` on `offer-promote-prod`, not the publish flag alone.

## Published versions

- `@chiubaka/circleci-orb@0.25.0`
